### PR TITLE
Fix comissions

### DIFF
--- a/src/backtest/__init__.py
+++ b/src/backtest/__init__.py
@@ -9,6 +9,9 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 from ..strategy import StrategyParams, SignalGenerator, TradeDirection
 
+DEFAULT_COMMISSION_PCT = 0.1
+DEFAULT_SLIPPAGE_PCT = 0.0
+
 
 @dataclass
 class Trade:
@@ -63,7 +66,8 @@ class BacktestResults:
     avg_mae: float = 0.0
     avg_mfe: float = 0.0
     initial_capital: float = 10000.0
-    commission_pct: float = 0.1
+    commission_pct: float = DEFAULT_COMMISSION_PCT
+    slippage_pct: float = DEFAULT_SLIPPAGE_PCT
     bars_per_year: int = 252
 
 
@@ -119,8 +123,8 @@ class BacktestEngine:
         self,
         params: StrategyParams,
         initial_capital: float = 10000,
-        commission_pct: float = 0.1,
-        slippage_pct: float = 0.0
+        commission_pct: float = DEFAULT_COMMISSION_PCT,
+        slippage_pct: float = DEFAULT_SLIPPAGE_PCT
     ):
         self.params = params
         self.initial_capital = initial_capital
@@ -641,6 +645,7 @@ class BacktestEngine:
                 realized_equity=realized_equity,
                 initial_capital=self.initial_capital,
                 commission_pct=self.commission_pct,
+                slippage_pct=self.slippage_pct,
                 bars_per_year=bars_per_year,
             )
 
@@ -791,5 +796,6 @@ class BacktestEngine:
             avg_mfe=avg_mfe,
             initial_capital=self.initial_capital,
             commission_pct=self.commission_pct,
+            slippage_pct=self.slippage_pct,
             bars_per_year=bars_per_year,
         )

--- a/src/backtest/__init__.py
+++ b/src/backtest/__init__.py
@@ -5,9 +5,9 @@ Backtest Module - v1.0.0
 
 import pandas as pd
 import numpy as np
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional, Tuple
-from ..strategy import StrategyParams, SignalGenerator, TradeDirection
+from ..strategy import StrategyParams, SignalGenerator
 
 DEFAULT_COMMISSION_PCT = 0.1
 DEFAULT_SLIPPAGE_PCT = 0.0

--- a/src/optimize/__init__.py
+++ b/src/optimize/__init__.py
@@ -49,7 +49,7 @@ def _suppress_warnings():
 
 # Entry-signal params — instability HERE means no reliable edge
 _ENTRY_PARAM_PREFIXES = (
-    'pamrp_length', 'pamrp_entry',
+    'pamrp_entry_length', 'pamrp_entry',
     'bbwp_length', 'bbwp_lookback', 'bbwp_sma', 'bbwp_threshold', 'bbwp_ma',
     'adx_length', 'adx_smoothing', 'adx_threshold',
     'ma_fast_length', 'ma_slow_length', 'ma_type',
@@ -61,6 +61,7 @@ _ENTRY_PARAM_PREFIXES = (
 
 # Exit/risk params — adapting between regimes is EXPECTED, not a red flag
 _EXIT_PARAM_PREFIXES = (
+    'pamrp_exit_length',
     'stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct',
     'atr_length', 'atr_multiplier',
     'time_exit_bars', 'ma_exit_fast', 'ma_exit_slow',
@@ -164,7 +165,7 @@ def _count_active_params(
     Pinned params are subtracted — they consume no trial dimensions.
     """
     dims_per_indicator = {
-        'pamrp_enabled': 5,
+        'pamrp_enabled': 4,
         'bbwp_enabled': 6,
         'adx_enabled': 3,
         'ma_trend_enabled': 3,
@@ -180,7 +181,7 @@ def _count_active_params(
         'time_exit_enabled': 1,
         'ma_exit_enabled': 2,
         'bbwp_exit_enabled': 1,
-        'pamrp_exit_enabled': 0,
+        'pamrp_exit_enabled': 3,
         'stoch_rsi_exit_enabled': 0,
     }
     total = sum(
@@ -381,7 +382,7 @@ class BayesianOptimizer:
         Parameters to hold fixed at their given values during optimization.
         Any param name listed here is NOT passed to trial.suggest_* —
         its value is taken directly from this dict instead.
-        Example: {'pamrp_length': 21, 'bbwp_lookback': 252}
+        Example: {'pamrp_entry_length': 21, 'bbwp_lookback': 252}
         Pinned params reduce the effective search-space dimensionality,
         which improves TPE convergence for the remaining free params.
     """
@@ -475,14 +476,15 @@ class BayesianOptimizer:
         long_or_both  = self.trade_direction in [TradeDirection.LONG_ONLY,  TradeDirection.BOTH]
         short_or_both = self.trade_direction in [TradeDirection.SHORT_ONLY, TradeDirection.BOTH]
 
-        pe  = ef.get('pamrp_enabled', False)
-        pl  = p_int('pamrp_length', 10, 30) if (pe or ef.get('pamrp_exit_enabled', False)) else 21
-        pel = p_int('pamrp_entry_long', 10, 40) if pe and long_or_both else 20
-        pes = p_int('pamrp_entry_short', 60, 90) if pe and short_or_both else 80
+        pe   = ef.get('pamrp_enabled', False)
+        peln = p_int('pamrp_entry_length', 10, 30) if pe else 21
+        pel  = p_int('pamrp_entry_long', 10, 40) if pe and long_or_both else 20
+        pes  = p_int('pamrp_entry_short', 60, 90) if pe and short_or_both else 80
 
-        pxe = ef.get('pamrp_exit_enabled', False)
-        pxl = p_int('pamrp_exit_long', 55, 90) if pxe and long_or_both else 70
-        pxs = p_int('pamrp_exit_short', 10, 45) if pxe and short_or_both else 30
+        pxe  = ef.get('pamrp_exit_enabled', False)
+        pxln = p_int('pamrp_exit_length', 10, 30) if pxe else 21
+        pxl  = p_int('pamrp_exit_long', 55, 90) if pxe and long_or_both else 70
+        pxs  = p_int('pamrp_exit_short', 10, 45) if pxe and short_or_both else 30
 
         be   = ef.get('bbwp_enabled', True)
         bl   = p_int('bbwp_length',         8,   21) if be else 13
@@ -554,8 +556,11 @@ class BayesianOptimizer:
             pxe = True
 
         return StrategyParams(
-            trade_direction=self.trade_direction, pamrp_enabled=pe, pamrp_length=pl,
+            trade_direction=self.trade_direction,
+            pamrp_enabled=pe,
+            pamrp_entry_length=peln,
             pamrp_entry_long=pel, pamrp_entry_short=pes, pamrp_exit_long=pxl, pamrp_exit_short=pxs,
+            pamrp_exit_length=pxln,
             bbwp_enabled=be, bbwp_length=bl, bbwp_lookback=blb, bbwp_sma_length=bsma,
             bbwp_threshold_long=btl, bbwp_threshold_short=bts, bbwp_ma_filter=bmf,
             adx_enabled=ae, adx_length=al, adx_smoothing=asm, adx_threshold=at,
@@ -922,7 +927,7 @@ def optimize_strategy(
         Keys are StrategyParams field names; values are the fixed values.
         Pinned params are excluded from trial.suggest_* calls, reducing
         search-space dimensionality and improving TPE convergence.
-        Example: {'pamrp_length': 21, 'stop_loss_pct_long': 3.0}
+        Example: {'pamrp_entry_length': 21, 'stop_loss_pct_long': 3.0}
 
     All other parameters are backward compatible with v6.
     """

--- a/src/optimize/__init__.py
+++ b/src/optimize/__init__.py
@@ -23,7 +23,12 @@ except ImportError:
     raise ImportError("Install optuna: pip install optuna")
 
 from ..strategy import StrategyParams, TradeDirection
-from ..backtest import BacktestEngine, BacktestResults
+from ..backtest import (
+    BacktestEngine,
+    BacktestResults,
+    DEFAULT_COMMISSION_PCT,
+    DEFAULT_SLIPPAGE_PCT,
+)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -134,7 +139,8 @@ class OptimizationResult:
     test_value: float = 0.0
     walkforward_folds: List[WalkForwardFold] = field(default_factory=list)
     initial_capital: float = 10000.0
-    commission_pct: float = 0.1
+    commission_pct: float = DEFAULT_COMMISSION_PCT
+    slippage_pct: float = DEFAULT_SLIPPAGE_PCT
     stitched_equity: Optional[pd.Series] = None
     efficiency_ratio: float = 0.0
     param_stability_cv: Dict[str, float] = field(default_factory=dict)
@@ -363,7 +369,7 @@ class BayesianOptimizer:
         BacktestResults attribute to optimize.
     min_trades : int
         Trials producing fewer trades are penalized to -inf.
-    initial_capital, commission_pct : float
+    initial_capital, commission_pct, slippage_pct : float
     trade_direction : str  — 'long_only' | 'short_only' | 'both'
     train_pct : float  — fraction for training in simple (non-WF) mode.
     use_walkforward : bool
@@ -387,7 +393,8 @@ class BayesianOptimizer:
         metric: str = 'sharpe_ratio',
         min_trades: int = 10,
         initial_capital: float = 10000,
-        commission_pct: float = 0.1,
+        commission_pct: float = DEFAULT_COMMISSION_PCT,
+        slippage_pct: float = DEFAULT_SLIPPAGE_PCT,
         trade_direction: str = 'long_only',
         train_pct: float = 0.7,
         use_walkforward: bool = False,
@@ -402,6 +409,7 @@ class BayesianOptimizer:
         self.min_trades = min_trades
         self.initial_capital = initial_capital
         self.commission_pct = commission_pct
+        self.slippage_pct = slippage_pct
         self.train_pct = train_pct
         self.use_walkforward = use_walkforward
         self.n_folds = n_folds
@@ -424,7 +432,12 @@ class BayesianOptimizer:
     # ── Backtest helpers ──────────────────────────────────────────────────────
 
     def _run_backtest(self, params: StrategyParams, df: pd.DataFrame) -> BacktestResults:
-        engine = BacktestEngine(params, self.initial_capital, self.commission_pct)
+        engine = BacktestEngine(
+            params,
+            self.initial_capital,
+            commission_pct=self.commission_pct,
+            slippage_pct=self.slippage_pct,
+        )
         return engine.run(df.copy())
 
     def _get_metric(self, results: BacktestResults) -> float:
@@ -755,6 +768,7 @@ class BayesianOptimizer:
             walkforward_folds=wf_folds,
             initial_capital=self.initial_capital,
             commission_pct=self.commission_pct,
+            slippage_pct=self.slippage_pct,
             stitched_equity=stitched_equity,
             efficiency_ratio=efficiency_ratio,
             param_stability_cv=param_stability_cv,
@@ -792,9 +806,17 @@ class BayesianOptimizer:
             return OptimizationResult(
                 best_params={}, best_value=0.0,
                 full_data_results=BacktestResults(
-                    trades=[], equity_curve=pd.Series(), realized_equity=pd.Series()),
+                    trades=[],
+                    equity_curve=pd.Series(),
+                    realized_equity=pd.Series(),
+                    initial_capital=self.initial_capital,
+                    commission_pct=self.commission_pct,
+                    slippage_pct=self.slippage_pct,
+                ),
                 all_trials=pd.DataFrame(), metric=self.metric,
-                initial_capital=self.initial_capital, commission_pct=self.commission_pct,
+                initial_capital=self.initial_capital,
+                commission_pct=self.commission_pct,
+                slippage_pct=self.slippage_pct,
                 failed_trial_pct=failed_pct, warnings=all_warnings, window_type='simple',
                 pinned_params=self.pinned_params,
             )
@@ -838,6 +860,7 @@ class BayesianOptimizer:
             walkforward_folds=[],
             initial_capital=self.initial_capital,
             commission_pct=self.commission_pct,
+            slippage_pct=self.slippage_pct,
             efficiency_ratio=efficiency_ratio,
             failed_trial_pct=failed_pct,
             warnings=all_warnings,
@@ -871,7 +894,8 @@ def optimize_strategy(
     n_trials: int = 200,
     min_trades: int = 10,
     initial_capital: float = 10000,
-    commission_pct: float = 0.1,
+    commission_pct: float = DEFAULT_COMMISSION_PCT,
+    slippage_pct: float = DEFAULT_SLIPPAGE_PCT,
     trade_direction: str = 'long_only',
     train_pct: float = 0.7,
     use_walkforward: bool = False,
@@ -909,6 +933,7 @@ def optimize_strategy(
         min_trades=min_trades,
         initial_capital=initial_capital,
         commission_pct=commission_pct,
+        slippage_pct=slippage_pct,
         trade_direction=trade_direction,
         train_pct=train_pct,
         use_walkforward=use_walkforward,

--- a/src/permutation/__init__.py
+++ b/src/permutation/__init__.py
@@ -21,7 +21,7 @@ If p < 0.05, we reject the null — the strategy's edge is unlikely due to chanc
 import numpy as np
 import pandas as pd
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
 from ..backtest import DEFAULT_COMMISSION_PCT, DEFAULT_SLIPPAGE_PCT

--- a/src/permutation/__init__.py
+++ b/src/permutation/__init__.py
@@ -20,8 +20,11 @@ If p < 0.05, we reject the null — the strategy's edge is unlikely due to chanc
 
 import numpy as np
 import pandas as pd
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
+
+from ..backtest import DEFAULT_COMMISSION_PCT, DEFAULT_SLIPPAGE_PCT
 
 
 @dataclass
@@ -89,7 +92,8 @@ def run_permutation_test(
     n_trials: int = 50,
     min_trades: int = 5,
     initial_capital: float = 10000,
-    commission_pct: float = 0.1,
+    commission_pct: float = DEFAULT_COMMISSION_PCT,
+    slippage_pct: float = DEFAULT_SLIPPAGE_PCT,
     trade_direction: str = 'long_only',
     train_pct: float = 0.7,
     seed: int = 42,
@@ -108,6 +112,7 @@ def run_permutation_test(
         min_trades: minimum trades for valid optimization
         initial_capital: starting capital
         commission_pct: commission percentage
+        slippage_pct: slippage percentage applied per fill
         trade_direction: 'long_only', 'short_only', 'both'
         train_pct: train/test split fraction
         seed: random seed
@@ -134,6 +139,7 @@ def run_permutation_test(
         min_trades=min_trades,
         initial_capital=initial_capital,
         commission_pct=commission_pct,
+        slippage_pct=slippage_pct,
         trade_direction=trade_direction,
         train_pct=train_pct,
         use_walkforward=False,
@@ -171,6 +177,7 @@ def run_permutation_test(
                 min_trades=min_trades,
                 initial_capital=initial_capital,
                 commission_pct=commission_pct,
+                slippage_pct=slippage_pct,
                 trade_direction=trade_direction,
                 train_pct=train_pct,
                 use_walkforward=False,

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -49,9 +49,10 @@ class StrategyParams:
 
     # PAMRP
     pamrp_enabled: bool = True
-    pamrp_length: int = 21
+    pamrp_entry_length: int = 21
     pamrp_entry_long: int = 20
     pamrp_entry_short: int = 80
+    pamrp_exit_length: int = 21
     pamrp_exit_long: int = 70
     pamrp_exit_short: int = 30
 
@@ -159,6 +160,10 @@ class StrategyParams:
         d = d.copy()
         if 'trade_direction' in d and isinstance(d['trade_direction'], str):
             d['trade_direction'] = TradeDirection(d['trade_direction'])
+        legacy_pamrp_length = d.pop('pamrp_length', None)
+        if legacy_pamrp_length is not None:
+            d.setdefault('pamrp_entry_length', legacy_pamrp_length)
+            d.setdefault('pamrp_exit_length', legacy_pamrp_length)
         valid_fields = set(cls.__dataclass_fields__.keys())
         return cls(**{k: v for k, v in d.items() if k in valid_fields})
 
@@ -173,9 +178,27 @@ class SignalGenerator:
         df = df.copy()
         p  = self.params
 
-        # PAMRP
-        df['pamrp'] = pamrp(df['high'], df['low'], df['close'], p.pamrp_length) \
-            if (p.pamrp_enabled or p.pamrp_exit_enabled) else 50.0
+        # PAMRP entry/exit can use different lookbacks.
+        if p.pamrp_enabled:
+            df['pamrp_entry'] = pamrp(df['high'], df['low'], df['close'], p.pamrp_entry_length)
+        else:
+            df['pamrp_entry'] = 50.0
+
+        if p.pamrp_exit_enabled:
+            if p.pamrp_enabled and p.pamrp_entry_length == p.pamrp_exit_length:
+                df['pamrp_exit'] = df['pamrp_entry']
+            else:
+                df['pamrp_exit'] = pamrp(df['high'], df['low'], df['close'], p.pamrp_exit_length)
+        else:
+            df['pamrp_exit'] = 50.0
+
+        # Keep the legacy column for callers that still expect one PAMRP series.
+        if p.pamrp_enabled:
+            df['pamrp'] = df['pamrp_entry']
+        elif p.pamrp_exit_enabled:
+            df['pamrp'] = df['pamrp_exit']
+        else:
+            df['pamrp'] = 50.0
 
         # BBWP
         if p.bbwp_enabled or p.bbwp_exit_enabled:
@@ -255,8 +278,8 @@ class SignalGenerator:
 
         if p.pamrp_enabled:
             has_any_filter = True
-            long_signal  = long_signal  & (df['pamrp'] < p.pamrp_entry_long)
-            short_signal = short_signal & (df['pamrp'] > p.pamrp_entry_short)
+            long_signal  = long_signal  & (df['pamrp_entry'] < p.pamrp_entry_long)
+            short_signal = short_signal & (df['pamrp_entry'] > p.pamrp_entry_short)
 
         if p.bbwp_enabled:
             has_any_filter = True
@@ -343,8 +366,8 @@ class SignalGenerator:
         exit_short = pd.Series(False, index=df.index)
 
         if p.pamrp_exit_enabled:
-            exit_long  = exit_long  | (df['pamrp'] > p.pamrp_exit_long)
-            exit_short = exit_short | (df['pamrp'] < p.pamrp_exit_short)
+            exit_long  = exit_long  | (df['pamrp_exit'] > p.pamrp_exit_long)
+            exit_short = exit_short | (df['pamrp_exit'] < p.pamrp_exit_short)
 
         if p.stoch_rsi_exit_enabled and 'stoch_k' in df.columns:
             exit_long  = exit_long  | (df['stoch_k'] > p.stoch_rsi_overbought)

--- a/tests/test_bh_comparison.py
+++ b/tests/test_bh_comparison.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from src.backtest import Trade
+from ui.tabs.backtest import _build_bh_comparison_window, _calculate_curve_stats
+
+
+def _make_results(index):
+    return SimpleNamespace(
+        equity_curve=pd.Series([10_000.0, 10_000.0, 11_000.0], index=index),
+        bars_per_year=252,
+        trades=[
+            Trade(
+                entry_idx=1,
+                entry_date=index[1],
+                entry_price=100.0,
+                direction='long',
+            )
+        ],
+    )
+
+
+def test_bh_comparison_full_window_uses_full_series():
+    index = pd.date_range('2024-01-01', periods=3, freq='D')
+    df = pd.DataFrame({'close': [100.0, 120.0, 130.0]}, index=index)
+    comparison = _build_bh_comparison_window(_make_results(index), df, 'full_window')
+
+    assert comparison is not None
+    assert comparison['start_date'] == index[0]
+    assert comparison['strategy_curve'].index[0] == index[0]
+    assert comparison['benchmark_curve'].iloc[0] == pytest.approx(10_000.0)
+    assert comparison['benchmark_curve'].iloc[-1] == pytest.approx(13_000.0)
+
+
+def test_bh_comparison_since_first_trade_slices_both_curves():
+    index = pd.date_range('2024-01-01', periods=3, freq='D')
+    df = pd.DataFrame({'close': [100.0, 120.0, 130.0]}, index=index)
+    comparison = _build_bh_comparison_window(_make_results(index), df, 'since_first_trade')
+
+    assert comparison is not None
+    assert comparison['start_date'] == index[1]
+    assert list(comparison['strategy_curve'].index) == list(index[1:])
+    assert comparison['benchmark_curve'].iloc[0] == pytest.approx(comparison['strategy_curve'].iloc[0])
+
+    strategy_stats = _calculate_curve_stats(comparison['strategy_curve'], 252)
+    benchmark_stats = _calculate_curve_stats(comparison['benchmark_curve'], 252)
+
+    assert strategy_stats['return_pct'] == pytest.approx(10.0)
+    assert benchmark_stats['return_pct'] == pytest.approx((130.0 / 120.0 - 1.0) * 100.0)

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -1,0 +1,39 @@
+from ui.state_migration import (
+    migrate_legacy_pamrp_params,
+    migrate_legacy_pamrp_pins,
+)
+
+
+def test_migrate_legacy_pamrp_params_splits_shared_length():
+    migrated = migrate_legacy_pamrp_params({
+        'pamrp_length': 34,
+        'pamrp_enabled': True,
+    })
+
+    assert 'pamrp_length' not in migrated
+    assert migrated['pamrp_entry_length'] == 34
+    assert migrated['pamrp_exit_length'] == 34
+
+
+def test_migrate_legacy_pamrp_params_keeps_explicit_split_lengths():
+    migrated = migrate_legacy_pamrp_params({
+        'pamrp_length': 34,
+        'pamrp_entry_length': 11,
+        'pamrp_exit_length': 27,
+    })
+
+    assert 'pamrp_length' not in migrated
+    assert migrated['pamrp_entry_length'] == 11
+    assert migrated['pamrp_exit_length'] == 27
+
+
+def test_migrate_legacy_pamrp_pins_replaces_legacy_pin_with_split_pins():
+    migrated = migrate_legacy_pamrp_pins({
+        'pamrp_length',
+        'bbwp_length',
+    })
+
+    assert 'pamrp_length' not in migrated
+    assert 'pamrp_entry_length' in migrated
+    assert 'pamrp_exit_length' in migrated
+    assert 'bbwp_length' in migrated

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -103,8 +103,10 @@ class TestStrategy:
         """Signal generator should add required columns"""
         gen = SignalGenerator(default_params)
         result = gen.generate_all_signals(sample_df)
-        
+
         assert 'pamrp' in result.columns
+        assert 'pamrp_entry' in result.columns
+        assert 'pamrp_exit' in result.columns
         assert 'bbwp' in result.columns
         assert 'entry_long' in result.columns
         assert 'entry_short' in result.columns
@@ -131,15 +133,32 @@ class TestStrategy:
         """Params should convert to dict"""
         d = default_params.to_dict()
         assert isinstance(d, dict)
-        assert 'pamrp_length' in d
+        assert 'pamrp_entry_length' in d
+        assert 'pamrp_exit_length' in d
         assert 'stop_loss_enabled' in d
-    
+
     def test_params_from_dict(self):
         """Params should be creatable from dict"""
         d = {'pamrp_length': 30, 'stop_loss_pct_long': 5.0}
         params = StrategyParams.from_dict(d)
-        assert params.pamrp_length == 30
+        assert params.pamrp_entry_length == 30
+        assert params.pamrp_exit_length == 30
         assert params.stop_loss_pct_long == 5.0
+
+    def test_pamrp_entry_and_exit_lengths_are_independent(self, sample_df):
+        """Entry and exit PAMRP should be calculated from separate lookbacks."""
+        params = StrategyParams(
+            pamrp_enabled=True,
+            pamrp_entry_length=10,
+            pamrp_exit_enabled=True,
+            pamrp_exit_length=30,
+        )
+        gen = SignalGenerator(params)
+        result = gen.calculate_indicators(sample_df)
+
+        diff = (result['pamrp_entry'] - result['pamrp_exit']).abs().dropna()
+        assert not diff.empty
+        assert (diff > 1e-9).any()
 
 
 class TestBacktest:

--- a/tests/test_transaction_costs.py
+++ b/tests/test_transaction_costs.py
@@ -1,0 +1,92 @@
+import inspect
+
+import pandas as pd
+import pytest
+
+from src.backtest import (
+    BacktestEngine,
+    BacktestResults,
+    DEFAULT_COMMISSION_PCT,
+    DEFAULT_SLIPPAGE_PCT,
+)
+from src.optimize import BayesianOptimizer, optimize_strategy
+from src.permutation import run_permutation_test
+from src.strategy import StrategyParams
+
+
+def test_transaction_cost_defaults_are_shared():
+    backtest_sig = inspect.signature(BacktestEngine.__init__)
+    optimize_sig = inspect.signature(optimize_strategy)
+    permutation_sig = inspect.signature(run_permutation_test)
+
+    assert backtest_sig.parameters['commission_pct'].default == DEFAULT_COMMISSION_PCT
+    assert backtest_sig.parameters['slippage_pct'].default == DEFAULT_SLIPPAGE_PCT
+    assert optimize_sig.parameters['commission_pct'].default == DEFAULT_COMMISSION_PCT
+    assert optimize_sig.parameters['slippage_pct'].default == DEFAULT_SLIPPAGE_PCT
+    assert permutation_sig.parameters['commission_pct'].default == DEFAULT_COMMISSION_PCT
+    assert permutation_sig.parameters['slippage_pct'].default == DEFAULT_SLIPPAGE_PCT
+
+
+def test_backtest_results_record_transaction_cost_settings():
+    idx = pd.date_range('2024-01-01', periods=2, freq='D')
+    equity = pd.Series([10_000.0, 10_000.0], index=idx)
+    results = BacktestResults(
+        trades=[],
+        equity_curve=equity,
+        realized_equity=equity,
+        commission_pct=0.25,
+        slippage_pct=0.40,
+    )
+
+    assert results.commission_pct == pytest.approx(0.25)
+    assert results.slippage_pct == pytest.approx(0.40)
+
+
+def test_optimizer_passes_slippage_to_backtest_engine(monkeypatch):
+    captured = {}
+
+    class DummyEngine:
+        def __init__(self, params, initial_capital, commission_pct, slippage_pct):
+            captured['initial_capital'] = initial_capital
+            captured['commission_pct'] = commission_pct
+            captured['slippage_pct'] = slippage_pct
+
+        def run(self, df):
+            return BacktestResults(
+                trades=[],
+                equity_curve=pd.Series(dtype=float),
+                realized_equity=pd.Series(dtype=float),
+                initial_capital=captured['initial_capital'],
+                commission_pct=captured['commission_pct'],
+                slippage_pct=captured['slippage_pct'],
+            )
+
+    monkeypatch.setattr('src.optimize.BacktestEngine', DummyEngine)
+
+    df = pd.DataFrame(
+        {
+            'open': [100.0, 101.0],
+            'high': [101.0, 102.0],
+            'low': [99.0, 100.0],
+            'close': [100.5, 101.5],
+            'volume': [1_000, 1_100],
+        },
+        index=pd.date_range('2024-01-01', periods=2, freq='D'),
+    )
+
+    opt = BayesianOptimizer(
+        df=df,
+        enabled_filters={},
+        initial_capital=25_000,
+        commission_pct=0.33,
+        slippage_pct=0.44,
+    )
+    result = opt._run_backtest(StrategyParams(), df)
+
+    assert captured == {
+        'initial_capital': 25_000,
+        'commission_pct': 0.33,
+        'slippage_pct': 0.44,
+    }
+    assert result.commission_pct == pytest.approx(0.33)
+    assert result.slippage_pct == pytest.approx(0.44)

--- a/ui/charts.py
+++ b/ui/charts.py
@@ -168,7 +168,10 @@ def create_price_chart_with_trades(
             overlay_inds.append('supertrend')
         if p.get('vwap_enabled') and 'vwap' in idf.columns:
             overlay_inds.append('vwap')
-        if (p.get('pamrp_enabled') or p.get('pamrp_exit_enabled')) and 'pamrp' in idf.columns:
+        if (
+            p.get('pamrp_enabled')
+            or p.get('pamrp_exit_enabled')
+        ) and any(col in idf.columns for col in ('pamrp_entry', 'pamrp_exit', 'pamrp')):
             sub_panel_inds.append('pamrp')
         if (p.get('bbwp_enabled') or p.get('bbwp_exit_enabled')) and 'bbwp' in idf.columns:
             sub_panel_inds.append('bbwp')
@@ -348,13 +351,43 @@ def create_price_chart_with_trades(
             rn = dict(row=row, col=1)
 
             if panel_name == 'pamrp':
-                fig.add_trace(go.Scatter(x=idf.index, y=idf['pamrp'], mode='lines',
-                    line=dict(color='#60a5fa', width=1.2),
-                    name='PAMRP', showlegend=True), **rn)
-                fig.add_hline(y=p.get('pamrp_entry_long', 20), line_dash='dash',
-                    line_color='rgba(16,185,129,0.6)', row=row, col=1)
-                fig.add_hline(y=p.get('pamrp_entry_short', 80), line_dash='dash',
-                    line_color='rgba(239,68,68,0.6)', row=row, col=1)
+                entry_length = p.get('pamrp_entry_length', p.get('pamrp_length', 21))
+                exit_length = p.get('pamrp_exit_length', p.get('pamrp_length', 21))
+                show_entry = p.get('pamrp_enabled') and 'pamrp_entry' in idf.columns
+                show_exit = p.get('pamrp_exit_enabled') and 'pamrp_exit' in idf.columns
+                same_length = entry_length == exit_length
+
+                if show_entry:
+                    fig.add_trace(go.Scatter(
+                        x=idf.index, y=idf['pamrp_entry'], mode='lines',
+                        line=dict(color='#60a5fa', width=1.2),
+                        name='PAMRP Entry' if show_exit and not same_length else 'PAMRP',
+                        showlegend=True,
+                    ), **rn)
+                elif 'pamrp' in idf.columns:
+                    fig.add_trace(go.Scatter(
+                        x=idf.index, y=idf['pamrp'], mode='lines',
+                        line=dict(color='#60a5fa', width=1.2),
+                        name='PAMRP', showlegend=True,
+                    ), **rn)
+
+                if show_exit and (not show_entry or not same_length):
+                    fig.add_trace(go.Scatter(
+                        x=idf.index, y=idf['pamrp_exit'], mode='lines',
+                        line=dict(color='#f59e0b', width=1.2, dash='dot'),
+                        name='PAMRP Exit', showlegend=True,
+                    ), **rn)
+
+                if p.get('pamrp_enabled'):
+                    fig.add_hline(y=p.get('pamrp_entry_long', 20), line_dash='dash',
+                        line_color='rgba(16,185,129,0.6)', row=row, col=1)
+                    fig.add_hline(y=p.get('pamrp_entry_short', 80), line_dash='dash',
+                        line_color='rgba(239,68,68,0.6)', row=row, col=1)
+                if p.get('pamrp_exit_enabled'):
+                    fig.add_hline(y=p.get('pamrp_exit_long', 70), line_dash='dot',
+                        line_color='rgba(245,158,11,0.7)', row=row, col=1)
+                    fig.add_hline(y=p.get('pamrp_exit_short', 30), line_dash='dot',
+                        line_color='rgba(249,115,22,0.7)', row=row, col=1)
                 fig.update_yaxes(title_text='PAMRP', range=[0, 100],
                     title_font=dict(size=8), row=row, col=1)
 

--- a/ui/charts.py
+++ b/ui/charts.py
@@ -28,6 +28,7 @@ from src.indicators import (
     hpdr_bands,
     rsi as compute_rsi,
 )
+from ui.state_migration import migrate_legacy_pamrp_params
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -154,7 +155,7 @@ def create_price_chart_with_trades(
 
     Y-axis of the price panel is always locked to the actual price range.
     """
-    p = params or {}
+    p = migrate_legacy_pamrp_params(params or {})
     idf = indicator_df
 
     # ── Decide which indicators to display ───────────────────────────────────
@@ -351,8 +352,8 @@ def create_price_chart_with_trades(
             rn = dict(row=row, col=1)
 
             if panel_name == 'pamrp':
-                entry_length = p.get('pamrp_entry_length', p.get('pamrp_length', 21))
-                exit_length = p.get('pamrp_exit_length', p.get('pamrp_length', 21))
+                entry_length = p.get('pamrp_entry_length', 21)
+                exit_length = p.get('pamrp_exit_length', 21)
                 show_entry = p.get('pamrp_enabled') and 'pamrp_entry' in idf.columns
                 show_exit = p.get('pamrp_exit_enabled') and 'pamrp_exit' in idf.columns
                 same_length = entry_length == exit_length

--- a/ui/charts.py
+++ b/ui/charts.py
@@ -566,19 +566,30 @@ def create_equity_chart(results) -> go.Figure:
     return fig
 
 
-def create_bh_comparison_chart(equity_curve: pd.Series, bh_prices: pd.Series) -> go.Figure:
+def create_bh_comparison_chart(
+    strategy_curve: pd.Series,
+    benchmark_curve: pd.Series,
+    benchmark_name: str = 'Buy & Hold',
+) -> go.Figure:
     """
     Dual normalized equity curve: Strategy vs Buy & Hold.
-    Both series are normalized to 100 at the start of the comparison window
-    (i.e. the first trade's entry date) so the curves share a common baseline.
+    Both series are normalized to 100 at the start of the chosen comparison
+    window so the curves share a common baseline.
     """
-    mask = equity_curve.index >= bh_prices.index[0]
-    strat = equity_curve.loc[mask]
-    if strat.empty or bh_prices.empty:
+    if strategy_curve.empty or benchmark_curve.empty:
+        return go.Figure()
+
+    common_index = strategy_curve.index.intersection(benchmark_curve.index)
+    if len(common_index) == 0:
+        return go.Figure()
+
+    strat = strategy_curve.loc[common_index]
+    bench = benchmark_curve.loc[common_index]
+    if strat.empty or bench.empty or strat.iloc[0] <= 0 or bench.iloc[0] <= 0:
         return go.Figure()
 
     strat_norm = strat / strat.iloc[0] * 100
-    bh_norm = bh_prices / bh_prices.iloc[0] * 100
+    bh_norm = bench / bench.iloc[0] * 100
 
     fig = go.Figure()
     fig.add_trace(go.Scatter(
@@ -588,14 +599,14 @@ def create_bh_comparison_chart(equity_curve: pd.Series, bh_prices: pd.Series) ->
     ))
     fig.add_trace(go.Scatter(
         x=bh_norm.index, y=bh_norm.values,
-        mode='lines', name='Buy & Hold',
+        mode='lines', name=benchmark_name,
         line=dict(color='#f59e0b', width=2, dash='dot'),
     ))
     fig.add_hline(y=100, line=dict(color='rgba(100,116,139,0.4)', width=1, dash='dash'))
     fig.update_layout(**_chart_layout(
         280, showlegend=True,
         legend=dict(orientation='h', y=1.12, font=dict(size=9)),
-        yaxis_title='Normalized (100 = entry)',
+        yaxis_title='Normalized (100 = window start)',
     ))
     fig.update_xaxes(rangeselector=dict(buttons=_RANGE_BUTTONS_SHORT, **_RANGE_SELECTOR_STYLE))
     fig.update_xaxes(gridcolor='rgba(45,53,72,0.3)')

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -22,8 +22,8 @@ from src.strategy import StrategyParams, TradeDirection
 # ─────────────────────────────────────────────────────────────────────────────
 
 PARAM_TO_WIDGET_KEY: Dict[str, str] = {
-    'pamrp_enabled': 'pe', 'pamrp_length': 'pl', 'pamrp_entry_long': 'pel', 'pamrp_entry_short': 'pes',
-    'pamrp_exit_long': 'pxl_exit', 'pamrp_exit_short': 'pxs_exit',
+    'pamrp_enabled': 'pe', 'pamrp_entry_length': 'ple', 'pamrp_entry_long': 'pel', 'pamrp_entry_short': 'pes',
+    'pamrp_exit_length': 'pxl_len', 'pamrp_exit_long': 'pxl_exit', 'pamrp_exit_short': 'pxs_exit',
     'bbwp_enabled': 'be', 'bbwp_length': 'bl', 'bbwp_lookback': 'blb', 'bbwp_sma_length': 'bsma',
     'bbwp_threshold_long': 'btl', 'bbwp_threshold_short': 'bts', 'bbwp_ma_filter': 'bmf',
     'adx_enabled': 'ae', 'adx_length': 'al', 'adx_threshold': 'at',
@@ -56,12 +56,15 @@ def params_to_strategy(p: Dict[str, Any]) -> StrategyParams:
         'Short Only': TradeDirection.SHORT_ONLY,
         'Both': TradeDirection.BOTH,
     }
+    legacy_pamrp_length = p.get('pamrp_length', 21)
     return StrategyParams(
         trade_direction=direction_map.get(p.get('trade_direction', 'Long Only'), TradeDirection.LONG_ONLY),
         position_size_pct=p.get('position_size_pct', 100.0),
         use_kelly=p.get('use_kelly', False), kelly_fraction=p.get('kelly_fraction', 0.5),
-        pamrp_enabled=p.get('pamrp_enabled', True), pamrp_length=p.get('pamrp_length', 21),
+        pamrp_enabled=p.get('pamrp_enabled', True),
+        pamrp_entry_length=p.get('pamrp_entry_length', legacy_pamrp_length),
         pamrp_entry_long=p.get('pamrp_entry_long', 20), pamrp_entry_short=p.get('pamrp_entry_short', 80),
+        pamrp_exit_length=p.get('pamrp_exit_length', legacy_pamrp_length),
         pamrp_exit_long=p.get('pamrp_exit_long', 70), pamrp_exit_short=p.get('pamrp_exit_short', 30),
         bbwp_enabled=p.get('bbwp_enabled', True), bbwp_length=p.get('bbwp_length', 13),
         bbwp_lookback=p.get('bbwp_lookback', 252), bbwp_sma_length=p.get('bbwp_sma_length', 5),
@@ -151,6 +154,10 @@ def apply_best_params_callback() -> None:
     if not res:
         return
     bp = res.best_params
+    legacy_pamrp_length = bp.get('pamrp_length')
+    if legacy_pamrp_length is not None:
+        bp.setdefault('pamrp_entry_length', legacy_pamrp_length)
+        bp.setdefault('pamrp_exit_length', legacy_pamrp_length)
     for k, v in bp.items():
         if isinstance(v, TradeDirection) or k == 'trade_direction':
             continue

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -164,5 +164,6 @@ def apply_best_params_callback() -> None:
         st.session_state.params['trade_direction'] = dm.get(bp['trade_direction_str'], 'Long Only')
     st.session_state.capital = res.initial_capital
     st.session_state.commission = res.commission_pct
+    st.session_state.slippage = getattr(res, 'slippage_pct', st.session_state.get('slippage', 0.0))
     st.session_state.backtest_results = None
     st.session_state._apply_success = True

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -15,6 +15,7 @@ import streamlit as st
 from typing import Dict, Any
 
 from src.strategy import StrategyParams, TradeDirection
+from ui.state_migration import migrate_legacy_pamrp_params
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -51,20 +52,20 @@ PARAM_TO_WIDGET_KEY: Dict[str, str] = {
 
 def params_to_strategy(p: Dict[str, Any]) -> StrategyParams:
     """Convert the flat session-state params dict into a typed StrategyParams object."""
+    p = migrate_legacy_pamrp_params(p)
     direction_map = {
         'Long Only': TradeDirection.LONG_ONLY,
         'Short Only': TradeDirection.SHORT_ONLY,
         'Both': TradeDirection.BOTH,
     }
-    legacy_pamrp_length = p.get('pamrp_length', 21)
     return StrategyParams(
         trade_direction=direction_map.get(p.get('trade_direction', 'Long Only'), TradeDirection.LONG_ONLY),
         position_size_pct=p.get('position_size_pct', 100.0),
         use_kelly=p.get('use_kelly', False), kelly_fraction=p.get('kelly_fraction', 0.5),
         pamrp_enabled=p.get('pamrp_enabled', True),
-        pamrp_entry_length=p.get('pamrp_entry_length', legacy_pamrp_length),
+        pamrp_entry_length=p.get('pamrp_entry_length', 21),
         pamrp_entry_long=p.get('pamrp_entry_long', 20), pamrp_entry_short=p.get('pamrp_entry_short', 80),
-        pamrp_exit_length=p.get('pamrp_exit_length', legacy_pamrp_length),
+        pamrp_exit_length=p.get('pamrp_exit_length', 21),
         pamrp_exit_long=p.get('pamrp_exit_long', 70), pamrp_exit_short=p.get('pamrp_exit_short', 30),
         bbwp_enabled=p.get('bbwp_enabled', True), bbwp_length=p.get('bbwp_length', 13),
         bbwp_lookback=p.get('bbwp_lookback', 252), bbwp_sma_length=p.get('bbwp_sma_length', 5),
@@ -153,11 +154,7 @@ def apply_best_params_callback() -> None:
     res = st.session_state.get('optimization_results')
     if not res:
         return
-    bp = res.best_params
-    legacy_pamrp_length = bp.get('pamrp_length')
-    if legacy_pamrp_length is not None:
-        bp.setdefault('pamrp_entry_length', legacy_pamrp_length)
-        bp.setdefault('pamrp_exit_length', legacy_pamrp_length)
+    bp = migrate_legacy_pamrp_params(res.best_params)
     for k, v in bp.items():
         if isinstance(v, TradeDirection) or k == 'trade_direction':
             continue

--- a/ui/session.py
+++ b/ui/session.py
@@ -18,8 +18,8 @@ def get_default_params() -> Dict[str, Any]:
     return {
         'trade_direction': 'Long Only',
         'position_size_pct': 100.0, 'use_kelly': False, 'kelly_fraction': 0.5,
-        'pamrp_enabled': False, 'pamrp_length': 21, 'pamrp_entry_long': 20, 'pamrp_entry_short': 80,
-        'pamrp_exit_long': 70, 'pamrp_exit_short': 30,
+        'pamrp_enabled': False, 'pamrp_entry_length': 21, 'pamrp_entry_long': 20, 'pamrp_entry_short': 80,
+        'pamrp_exit_length': 21, 'pamrp_exit_long': 70, 'pamrp_exit_short': 30,
         'bbwp_enabled': False, 'bbwp_length': 13, 'bbwp_lookback': 252, 'bbwp_sma_length': 5,
         'bbwp_threshold_long': 50, 'bbwp_threshold_short': 50, 'bbwp_ma_filter': 'disabled',
         'adx_enabled': False, 'adx_length': 14, 'adx_smoothing': 14, 'adx_threshold': 20,
@@ -68,6 +68,11 @@ def init_session_state() -> None:
     for key, default in defaults:
         if key not in st.session_state:
             st.session_state[key] = default
+
+    legacy_pamrp_length = st.session_state.params.get('pamrp_length')
+    if legacy_pamrp_length is not None:
+        st.session_state.params.setdefault('pamrp_entry_length', legacy_pamrp_length)
+        st.session_state.params.setdefault('pamrp_exit_length', legacy_pamrp_length)
 
     # Forward-fill any new keys missing from an older session state
     for k, v in get_default_params().items():

--- a/ui/session.py
+++ b/ui/session.py
@@ -12,6 +12,7 @@ import streamlit as st
 from typing import Any, Dict
 
 from src.backtest import DEFAULT_COMMISSION_PCT, DEFAULT_SLIPPAGE_PCT
+from ui.state_migration import migrate_legacy_pamrp_params, migrate_legacy_pamrp_pins
 
 
 def get_default_params() -> Dict[str, Any]:
@@ -69,10 +70,10 @@ def init_session_state() -> None:
         if key not in st.session_state:
             st.session_state[key] = default
 
-    legacy_pamrp_length = st.session_state.params.get('pamrp_length')
-    if legacy_pamrp_length is not None:
-        st.session_state.params.setdefault('pamrp_entry_length', legacy_pamrp_length)
-        st.session_state.params.setdefault('pamrp_exit_length', legacy_pamrp_length)
+    st.session_state.params = migrate_legacy_pamrp_params(st.session_state.params)
+    st.session_state.pinned_params = migrate_legacy_pamrp_pins(
+        st.session_state.get('pinned_params', set())
+    )
 
     # Forward-fill any new keys missing from an older session state
     for k, v in get_default_params().items():

--- a/ui/session.py
+++ b/ui/session.py
@@ -11,6 +11,8 @@ for every strategy parameter key and its initial value.
 import streamlit as st
 from typing import Any, Dict
 
+from src.backtest import DEFAULT_COMMISSION_PCT, DEFAULT_SLIPPAGE_PCT
+
 
 def get_default_params() -> Dict[str, Any]:
     return {
@@ -59,7 +61,8 @@ def init_session_state() -> None:
         ('backtest_results', None),
         ('optimization_results', None),
         ('capital', 10000),
-        ('commission', 1.0),
+        ('commission', DEFAULT_COMMISSION_PCT),
+        ('slippage', DEFAULT_SLIPPAGE_PCT),
         ('pinned_params', set()),
     ]
     for key, default in defaults:

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -152,8 +152,7 @@ def _render_entry_indicators(p: dict) -> None:
     with st.expander("📊 PAMRP", expanded=False):
         p['pamrp_enabled'] = st.toggle("Enable", p['pamrp_enabled'], key="pe")
         if p['pamrp_enabled']:
-            length_label = "Length (shared with PAMRP Exit)" if p.get('pamrp_exit_enabled') else "Length"
-            p['pamrp_length'] = st.slider(length_label, 5, 50, p['pamrp_length'], key="pl")
+            p['pamrp_entry_length'] = st.slider("Length", 5, 50, p['pamrp_entry_length'], key="ple")
             p['pamrp_entry_long'] = st.slider("Entry Long", 5, 50, p['pamrp_entry_long'], key="pel")
             p['pamrp_entry_short'] = st.slider("Entry Short", 50, 95, p['pamrp_entry_short'], key="pes")
 
@@ -277,17 +276,7 @@ def _render_exit_indicators(p: dict) -> None:
     with st.expander("📊 PAMRP Exit", expanded=False):
         p['pamrp_exit_enabled'] = st.toggle("Enable", p['pamrp_exit_enabled'], key="pxe")
         if p['pamrp_exit_enabled']:
-            if p.get('pamrp_enabled'):
-                st.caption(f"Length: {p['pamrp_length']} (shared with PAMRP entry)")
-            else:
-                p['pamrp_length'] = st.slider(
-                    "Length",
-                    5,
-                    50,
-                    p['pamrp_length'],
-                    key="pl",
-                    help="PAMRP period — shared with entry when enabled.",
-                )
+            p['pamrp_exit_length'] = st.slider("Length", 5, 50, p['pamrp_exit_length'], key="pxl_len")
             p['pamrp_exit_long']  = st.slider("Exit Long (overbought)", 50, 100, p['pamrp_exit_long'],  key="pxl_exit")
             p['pamrp_exit_short'] = st.slider("Exit Short (oversold)",  0,   50,  p['pamrp_exit_short'], key="pxs_exit")
 

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -152,7 +152,8 @@ def _render_entry_indicators(p: dict) -> None:
     with st.expander("📊 PAMRP", expanded=False):
         p['pamrp_enabled'] = st.toggle("Enable", p['pamrp_enabled'], key="pe")
         if p['pamrp_enabled']:
-            p['pamrp_length'] = st.slider("Length", 5, 50, p['pamrp_length'], key="pl")
+            length_label = "Length (shared with PAMRP Exit)" if p.get('pamrp_exit_enabled') else "Length"
+            p['pamrp_length'] = st.slider(length_label, 5, 50, p['pamrp_length'], key="pl")
             p['pamrp_entry_long'] = st.slider("Entry Long", 5, 50, p['pamrp_entry_long'], key="pel")
             p['pamrp_entry_short'] = st.slider("Entry Short", 50, 95, p['pamrp_entry_short'], key="pes")
 
@@ -276,8 +277,17 @@ def _render_exit_indicators(p: dict) -> None:
     with st.expander("📊 PAMRP Exit", expanded=False):
         p['pamrp_exit_enabled'] = st.toggle("Enable", p['pamrp_exit_enabled'], key="pxe")
         if p['pamrp_exit_enabled']:
-            p['pamrp_length']     = st.slider("Length", 5, 50, p['pamrp_length'], key="pxl_len",
-                help="PAMRP period — shared with entry if both enabled.")
+            if p.get('pamrp_enabled'):
+                st.caption(f"Length: {p['pamrp_length']} (shared with PAMRP entry)")
+            else:
+                p['pamrp_length'] = st.slider(
+                    "Length",
+                    5,
+                    50,
+                    p['pamrp_length'],
+                    key="pl",
+                    help="PAMRP period — shared with entry when enabled.",
+                )
             p['pamrp_exit_long']  = st.slider("Exit Long (overbought)", 50, 100, p['pamrp_exit_long'],  key="pxl_exit")
             p['pamrp_exit_short'] = st.slider("Exit Short (oversold)",  0,   50,  p['pamrp_exit_short'], key="pxs_exit")
 

--- a/ui/state_migration.py
+++ b/ui/state_migration.py
@@ -1,0 +1,39 @@
+"""
+ui/state_migration.py
+=====================
+Helpers for migrating persisted UI/session state across renamed parameters.
+"""
+
+from typing import Any, Dict, Iterable, Set
+
+LEGACY_PAMRP_LENGTH_KEY = 'pamrp_length'
+PAMRP_LENGTH_KEYS = ('pamrp_entry_length', 'pamrp_exit_length')
+
+
+def migrate_legacy_pamrp_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Expand the legacy shared PAMRP length into the split entry/exit lengths.
+
+    Returns a copy so callers can safely normalize session state, optimization
+    results, or other persisted payloads without mutating the original object.
+    """
+    migrated = dict(params)
+    legacy_length = migrated.pop(LEGACY_PAMRP_LENGTH_KEY, None)
+    if legacy_length is not None:
+        migrated.setdefault('pamrp_entry_length', legacy_length)
+        migrated.setdefault('pamrp_exit_length', legacy_length)
+    return migrated
+
+
+def migrate_legacy_pamrp_pins(pinned_params: Iterable[str] | None) -> Set[str]:
+    """
+    Replace the legacy shared-length pin with the split entry/exit pins.
+
+    The old `pamrp_length` controlled both paths, so the safest migration is to
+    pin both renamed fields.
+    """
+    migrated = set(pinned_params or ())
+    if LEGACY_PAMRP_LENGTH_KEY in migrated:
+        migrated.discard(LEGACY_PAMRP_LENGTH_KEY)
+        migrated.update(PAMRP_LENGTH_KEYS)
+    return migrated

--- a/ui/tabs/backtest.py
+++ b/ui/tabs/backtest.py
@@ -20,6 +20,11 @@ from ui.charts import (
     PLOTLY_CONFIG,
 )
 
+BH_WINDOW_OPTIONS = {
+    'full_window': 'Since start of data',
+    'since_first_trade': 'Since first strategy trade',
+}
+
 
 def render_backtest_tab() -> None:
     c1, c2, c3, c4 = st.columns([2, 1, 1, 1])
@@ -158,9 +163,92 @@ def render_backtest_tab() -> None:
     _render_trade_log()
 
     # ── Strategy vs Buy & Hold ─────────────────────────────────────────────
-    if st.session_state.backtest_results and st.session_state.backtest_results.trades:
+    if st.session_state.backtest_results and st.session_state.df is not None:
         with st.expander("⚖️ Strategy vs Buy & Hold", expanded=False):
             _render_bh_comparison(st.session_state.backtest_results, st.session_state.df)
+
+
+def _calculate_curve_stats(curve: pd.Series, bars_per_year: int) -> dict[str, float]:
+    """Calculate comparable performance stats for any equity-like curve."""
+    if curve is None or len(curve) == 0:
+        return {'return_pct': 0.0, 'cagr': 0.0, 'max_dd_pct': 0.0, 'sharpe': 0.0}
+
+    start_val = float(curve.iloc[0])
+    end_val = float(curve.iloc[-1])
+
+    if start_val > 0:
+        total_return_pct = (end_val / start_val - 1.0) * 100
+    else:
+        total_return_pct = 0.0
+
+    n_bars = len(curve)
+    if n_bars > 1 and start_val > 0 and end_val > 0:
+        cagr = ((end_val / start_val) ** (bars_per_year / n_bars) - 1.0) * 100
+    else:
+        cagr = 0.0
+
+    peak = curve.expanding().max()
+    max_dd_pct = float(((curve - peak) / peak).min() * 100) if peak.max() > 0 else 0.0
+
+    returns = curve.pct_change().dropna()
+    active_returns = returns[returns != 0]
+    n_total_rets = len(returns)
+    n_active = len(active_returns)
+
+    if n_total_rets > 0 and n_active > 0:
+        active_bars_per_year = n_active * (bars_per_year / n_total_rets)
+    else:
+        active_bars_per_year = bars_per_year
+
+    if n_active > 1 and active_returns.std() > 0:
+        sharpe = float((active_returns.mean() / active_returns.std()) * np.sqrt(active_bars_per_year))
+    else:
+        sharpe = 0.0
+
+    return {
+        'return_pct': float(total_return_pct),
+        'cagr': float(cagr),
+        'max_dd_pct': max_dd_pct,
+        'sharpe': sharpe,
+    }
+
+
+def _build_bh_comparison_window(r, df: pd.DataFrame, window_mode: str) -> dict | None:
+    """Build aligned strategy and passive benchmark curves for the chosen window."""
+    if df is None or df.empty or r.equity_curve is None or len(r.equity_curve) == 0:
+        return None
+
+    if window_mode == 'since_first_trade' and r.trades:
+        window_label = BH_WINDOW_OPTIONS['since_first_trade']
+        start_date = r.trades[0].entry_date
+    else:
+        window_label = BH_WINDOW_OPTIONS['full_window']
+        start_date = df.index[0]
+
+    strategy_curve = r.equity_curve.loc[r.equity_curve.index >= start_date]
+    benchmark_prices = df.loc[df.index >= start_date, 'close']
+    common_index = strategy_curve.index.intersection(benchmark_prices.index)
+
+    if len(common_index) == 0:
+        return None
+
+    strategy_curve = strategy_curve.loc[common_index]
+    benchmark_prices = benchmark_prices.loc[common_index]
+
+    start_equity = float(strategy_curve.iloc[0])
+    start_price = float(benchmark_prices.iloc[0])
+    if start_equity <= 0 or start_price <= 0:
+        return None
+
+    benchmark_curve = benchmark_prices / start_price * start_equity
+
+    return {
+        'window_label': window_label,
+        'start_date': common_index[0],
+        'end_date': common_index[-1],
+        'strategy_curve': strategy_curve,
+        'benchmark_curve': benchmark_curve,
+    }
 
 
 def _render_trade_log() -> None:
@@ -213,39 +301,69 @@ def _render_trade_log() -> None:
 
 def _render_bh_comparison(r, df: pd.DataFrame) -> None:
     """Inline Strategy vs Buy & Hold comparison panel."""
-    ft = r.trades[0]
-    ep = ft.entry_price
-    ed = ft.entry_date
-    fp = df['close'].iloc[-1]
-    bh_pct = (fp - ep) / ep * 100  # B&H is always a long position
-    mask = df.index >= ed
-    prices = df.loc[mask, 'close']
-    peak = prices.expanding().max()
-    bh_dd = ((prices - peak) / peak * 100).min()
+    available_modes = ['full_window']
+    if r.trades:
+        available_modes.append('since_first_trade')
+
+    default_mode = st.session_state.get('bh_window_mode', available_modes[0])
+    if default_mode not in available_modes:
+        default_mode = available_modes[0]
+
+    selected_mode = st.radio(
+        "Benchmark Window",
+        available_modes,
+        format_func=lambda m: BH_WINDOW_OPTIONS[m],
+        horizontal=True,
+        index=available_modes.index(default_mode),
+        key="bh_window_mode",
+    )
+
+    comparison = _build_bh_comparison_window(r, df, selected_mode)
+    if comparison is None:
+        st.warning("Unable to build the buy-and-hold comparison for the selected window.")
+        return
+
+    strategy_curve = comparison['strategy_curve']
+    benchmark_curve = comparison['benchmark_curve']
+    strategy_stats = _calculate_curve_stats(strategy_curve, r.bars_per_year)
+    benchmark_stats = _calculate_curve_stats(benchmark_curve, r.bars_per_year)
+
+    st.caption("Benchmark is always long-only buy & hold of the underlying asset, regardless of strategy direction.")
+    st.caption(
+        f"Window: {comparison['window_label']} · "
+        f"{comparison['start_date'].date()} → {comparison['end_date'].date()}"
+    )
+    if not r.trades:
+        st.caption("No trades were taken, so only the full-data comparison window is available.")
 
     st.dataframe(
         pd.DataFrame([
-            {'Strategy': '📊 Yours', 'Return %': f"{r.total_return_pct:.2f}%",
-             'CAGR': f"{r.cagr:.2f}%", 'Max DD': f"{r.max_drawdown_pct:.2f}%",
-             'Sharpe': f"{r.sharpe_ratio:.3f}"},
-            {'Strategy': '📈 B&H', 'Return %': f"{bh_pct:.2f}%",
-             'CAGR': '-', 'Max DD': f"{bh_dd:.2f}%", 'Sharpe': '-'},
+            {'Strategy': '📊 Strategy', 'Return %': f"{strategy_stats['return_pct']:.2f}%",
+             'CAGR': f"{strategy_stats['cagr']:.2f}%", 'Max DD': f"{strategy_stats['max_dd_pct']:.2f}%",
+             'Sharpe': f"{strategy_stats['sharpe']:.3f}"},
+            {'Strategy': '📈 Buy & Hold (Long-only)', 'Return %': f"{benchmark_stats['return_pct']:.2f}%",
+             'CAGR': f"{benchmark_stats['cagr']:.2f}%", 'Max DD': f"{benchmark_stats['max_dd_pct']:.2f}%",
+             'Sharpe': f"{benchmark_stats['sharpe']:.3f}"},
         ]),
         use_container_width=True, hide_index=True,
     )
 
-    diff = r.total_return_pct - bh_pct
+    diff = strategy_stats['return_pct'] - benchmark_stats['return_pct']
     msg = f"{'🏆 Strategy beats Buy & Hold by' if diff > 0 else '📉 B&H beats strategy by'} {abs(diff):.2f}%"
     (st.success if diff > 0 else st.warning)(msg)
 
     st.plotly_chart(
-        create_bh_comparison_chart(r.equity_curve, prices),
+        create_bh_comparison_chart(
+            strategy_curve,
+            benchmark_curve,
+            benchmark_name='Buy & Hold (Long-only)',
+        ),
         use_container_width=True, config=PLOTLY_CONFIG,
     )
 
     ba = calculate_beta_alpha(
-        r.equity_curve.pct_change().dropna(),
-        prices.pct_change().dropna(),
+        strategy_curve.pct_change().dropna(),
+        benchmark_curve.pct_change().dropna(),
     )
     c1, c2, c3 = st.columns(3)
     c1.metric("Beta", f"{ba['beta']:.3f}")

--- a/ui/tabs/backtest.py
+++ b/ui/tabs/backtest.py
@@ -24,11 +24,30 @@ from ui.charts import (
 def render_backtest_tab() -> None:
     c1, c2, c3, c4 = st.columns([2, 1, 1, 1])
     st.session_state.capital = c1.number_input("Capital $", 1000, 1000000, st.session_state.capital, 1000)
-    st.session_state.commission = c2.number_input("Comm %", 0.0, 1.0, st.session_state.commission, 0.01)
-    slippage = c3.number_input("Slip %", 0.0, 0.5, 0.0, 0.01)
+    st.session_state.commission = c2.number_input(
+        "Comm / side %",
+        min_value=0.0,
+        value=st.session_state.commission,
+        step=0.01,
+        format="%.2f",
+        help="Applied on entry and exit. A 0.10% commission becomes 0.20% round-trip.",
+    )
+    st.session_state.slippage = c3.number_input(
+        "Slip / fill %",
+        min_value=0.0,
+        value=st.session_state.slippage,
+        step=0.01,
+        format="%.2f",
+        help="Applied on entries and non-gap-aware exits. No hard UI cap.",
+    )
     with c4:
         st.markdown("<br>", unsafe_allow_html=True)
         run = st.button("🚀 Run", type="primary", use_container_width=True)
+
+    st.caption(
+        f"Round-trip commission: {st.session_state.commission * 2:.2f}% | "
+        f"Slippage setting: {st.session_state.slippage:.2f}% per fill"
+    )
 
     if run:
         if st.session_state.df is None:
@@ -39,7 +58,7 @@ def render_backtest_tab() -> None:
                     params_to_strategy(st.session_state.params),
                     st.session_state.capital,
                     st.session_state.commission,
-                    slippage,
+                    st.session_state.slippage,
                 )
                 st.session_state.backtest_results = engine.run(st.session_state.df.copy())
                 st.success(f"✅ {st.session_state.backtest_results.num_trades} trades")

--- a/ui/tabs/heatmap.py
+++ b/ui/tabs/heatmap.py
@@ -21,7 +21,7 @@ from ui.charts import _chart_layout
 # Local chart factory
 # ─────────────────────────────────────────────────────────────────────────────
 
-def create_heatmap(df, param1, param2, metric, params, capital, commission) -> go.Figure:
+def create_heatmap(df, param1, param2, metric, params, capital, commission, slippage) -> go.Figure:
     ranges = {
         'pamrp_entry_long': list(range(10, 45, 5)),
         'pamrp_exit_long': list(range(50, 95, 5)),
@@ -39,7 +39,12 @@ def create_heatmap(df, param1, param2, metric, params, capital, commission) -> g
             tp[param2] = v2
             try:
                 m[j, i] = getattr(
-                    BacktestEngine(params_to_strategy(tp), capital, commission).run(df.copy()),
+                    BacktestEngine(
+                        params_to_strategy(tp),
+                        capital,
+                        commission,
+                        slippage,
+                    ).run(df.copy()),
                     metric, 0)
             except:
                 m[j, i] = 0
@@ -73,6 +78,7 @@ def render_heatmap_tab() -> None:
                         st.session_state.params,
                         st.session_state.capital,
                         st.session_state.commission,
+                        st.session_state.slippage,
                     ),
                     use_container_width=True,
                 )

--- a/ui/tabs/montecarlo.py
+++ b/ui/tabs/montecarlo.py
@@ -145,6 +145,7 @@ def render_montecarlo_tab() -> None:
                     min_trades=perm_min,
                     initial_capital=st.session_state.capital,
                     commission_pct=st.session_state.commission,
+                    slippage_pct=st.session_state.slippage,
                     trade_direction=perm_dir,
                     train_pct=0.7,
                     progress_callback=_progress,

--- a/ui/tabs/montecarlo.py
+++ b/ui/tabs/montecarlo.py
@@ -14,6 +14,7 @@ from ui.charts import (
     create_mc_histogram,
     _chart_layout,PLOTLY_CONFIG
 )
+from ui.state_migration import migrate_legacy_pamrp_pins
 
 
 def render_montecarlo_tab() -> None:
@@ -115,21 +116,21 @@ def render_montecarlo_tab() -> None:
             st.warning("Load data first!")
         else:
             from src.permutation import run_permutation_test
-            from ui.helpers import get_active_filters_display
 
             p = st.session_state.params
             enabled_filters = {k: v for k, v in p.items() if k.endswith('_enabled') and isinstance(v, bool)}
 
             # Collect pinned params from session state
             pinned = {}
-            pinned_set = st.session_state.get('pinned_params', set())
+            pinned_set = migrate_legacy_pamrp_pins(st.session_state.get('pinned_params', set()))
+            if pinned_set != st.session_state.get('pinned_params', set()):
+                st.session_state.pinned_params = pinned_set
             if pinned_set:
                 for pk in pinned_set:
                     if pk in p:
                         pinned[pk] = p[pk]
 
             progress_bar = st.progress(0, text="Optimizing on real data...")
-            status_text = st.empty()
 
             def _progress(current, total):
                 pct = current / total
@@ -153,7 +154,6 @@ def render_montecarlo_tab() -> None:
                 )
 
             progress_bar.empty()
-            status_text.empty()
 
             if perm_result:
                 st.session_state._perm_result = perm_result

--- a/ui/tabs/multi_asset.py
+++ b/ui/tabs/multi_asset.py
@@ -32,6 +32,7 @@ def render_multi_asset_tab() -> None:
                         params_to_strategy(st.session_state.params),
                         st.session_state.capital,
                         st.session_state.commission,
+                        st.session_state.slippage,
                     ).run(df)
                 except Exception as e:
                     st.warning(f"{sym}: {str(e)[:30]}")

--- a/ui/tabs/optimize.py
+++ b/ui/tabs/optimize.py
@@ -10,6 +10,7 @@ import streamlit as st
 from src.optimize import optimize_strategy
 from src.strategy import TradeDirection
 from ui.helpers import get_active_filters_display, apply_best_params_callback
+from ui.state_migration import migrate_legacy_pamrp_pins
 from ui.charts import (
     create_walkforward_chart,
     create_stitched_equity_chart,
@@ -96,9 +97,12 @@ def render_optimize_tab() -> None:
         if st.session_state.df is None:
             st.warning("Load data first!")
         else:
+            normalized_pins = migrate_legacy_pamrp_pins(st.session_state.pinned_params)
+            if normalized_pins != st.session_state.pinned_params:
+                st.session_state.pinned_params = normalized_pins
             ef = {k: v for k, v in st.session_state.params.items() if k.endswith('_enabled')}
             pinned_dict = {k: st.session_state.params[k]
-                           for k in st.session_state.pinned_params
+                           for k in normalized_pins
                            if k in st.session_state.params}
             with st.spinner("Optimizing..."):
                 res = optimize_strategy(
@@ -125,9 +129,10 @@ def _render_pin_expander() -> None:
         for ind_key, params_list in _PINNABLE.items()
         if st.session_state.params.get(ind_key, False)
     ]
-    pinned_set: set = st.session_state.pinned_params
+    pinned_set: set = migrate_legacy_pamrp_pins(st.session_state.pinned_params)
 
     if not enabled_pinnable:
+        st.session_state.pinned_params = pinned_set
         return
 
     with st.expander("🔒 Pin Parameters (hold fixed during optimization)", expanded=False):

--- a/ui/tabs/optimize.py
+++ b/ui/tabs/optimize.py
@@ -104,6 +104,7 @@ def render_optimize_tab() -> None:
                     df=st.session_state.df.copy(), enabled_filters=ef,
                     metric=opt_metric, n_trials=opt_trials, min_trades=opt_min,
                     initial_capital=st.session_state.capital, commission_pct=st.session_state.commission,
+                    slippage_pct=st.session_state.slippage,
                     trade_direction=opt_dir, train_pct=train_pct / 100, use_walkforward=use_wf,
                     n_folds=n_folds, window_type=window_type, train_window_bars=train_window_bars,
                     show_progress=False, pinned_params=pinned_dict if pinned_dict else None)
@@ -221,4 +222,8 @@ def _render_results() -> None:
 
     st.button("📋 Apply Best Params", on_click=apply_best_params_callback, use_container_width=True)
     if st.session_state.pop('_apply_success', False):
-        st.success(f"✅ Applied! Capital: ${st.session_state.capital:,.0f} | Commission: {st.session_state.commission}%")
+        st.success(
+            f"✅ Applied! Capital: ${st.session_state.capital:,.0f} | "
+            f"Commission: {st.session_state.commission:.2f}% | "
+            f"Slippage: {st.session_state.slippage:.2f}%"
+        )

--- a/ui/tabs/optimize.py
+++ b/ui/tabs/optimize.py
@@ -22,9 +22,10 @@ from ui.charts import (
 # ─────────────────────────────────────────────────────────────────────────────
 
 _PINNABLE = {
-    'pamrp_enabled': [('pamrp_length', 'Length'), ('pamrp_entry_long', 'Entry Long'),
+    'pamrp_enabled': [('pamrp_entry_length', 'Length'), ('pamrp_entry_long', 'Entry Long'),
         ('pamrp_entry_short', 'Entry Short')],
-    'pamrp_exit_enabled': [('pamrp_exit_long', 'Exit Long'), ('pamrp_exit_short', 'Exit Short')],
+    'pamrp_exit_enabled': [('pamrp_exit_length', 'Length'), ('pamrp_exit_long', 'Exit Long'),
+        ('pamrp_exit_short', 'Exit Short')],
     'bbwp_enabled': [('bbwp_length', 'Length'), ('bbwp_lookback', 'Lookback'), ('bbwp_sma_length', 'SMA Length'),
         ('bbwp_ma_filter', 'MA Filter'), ('bbwp_threshold_long', 'Thresh Long'), ('bbwp_threshold_short', 'Thresh Short')],
     'adx_enabled': [('adx_length', 'Length'), ('adx_smoothing', 'Smoothing'), ('adx_threshold', 'Threshold')],


### PR DESCRIPTION
feat: split PAMRP lengths and wire transaction costs through the UI

- add separate PAMRP entry/exit lengths across strategy, optimizer, charts,
  and sidebar controls
- propagate commission/slippage defaults and settings through backtest,
  optimization, heatmap, multi-asset, and permutation flows #26 
- rework Strategy vs Buy & Hold comparison windows and benchmark stats/charts #25 
- migrate legacy pamrp_length state and pinned params to the renamed fields
- remove dead legacy/unused code and add regression coverage for migration
  and transaction-cost behavior
