### PR TITLE
Full stack refractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ joe_usd_1d.csv
 .serena
 RESEARCH_LOG.md
 venv/
+fixtures/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,25 +152,31 @@ you must justify why an existing indicator can't be adapted via parameters.
 
 **Procedure:**
 
-1. Generate a spec file matching the schema in `src/indicators/specs/`.
-2. Register it via the MCP tool. The registry validator runs automatically —
-   schema check, look-ahead check, determinism check.
-3. The new indicator is `provisional=True` until permutation-tested. It
-   cannot be used in a final recommendation until it passes p < 0.05 on
-   its own (not just as part of a strategy).
-4. Run the same characterize → baseline → diagnose loop on the new indicator
-   that you would on any existing one. The hard limit is still two entry
-   indicators per strategy.
-5. If the indicator survives permutation testing on multiple symbols/regimes,
-   propose promotion from `provisional=True` to permanent. Promotion is a
-   human gate.
+1. `list_indicators` — confirm the signal doesn't already exist under another name.
+2. Write the spec source. No import statements — use `pd`, `np`, `IndicatorSpec`,
+   `ParamSpec`, `register`, and any `src.indicators` compute primitives (`sma`, `ema`,
+   `rsi`, `atr`, etc.) which are pre-loaded in the execution namespace.
+   Compute and signal functions must be named callables, not lambdas.
+3. `register_indicator(spec_source)` — runs syntax check, import whitelist,
+   schema validation, and output column check automatically. Fix any errors
+   it reports before proceeding.
+4. `set_params({"new_key_enabled": True})` + `run_backtest()` — verify the
+   indicator produces trades and the signal is directionally sensible.
+5. Continue the normal characterize → optimize → permutation loop.
+   The two-indicator hard limit still applies.
+6. The indicator is provisional until it passes `run_permutation_test` (p < 0.05).
+   Treat results with extra skepticism until then — a new indicator that
+   immediately produces great metrics is more likely look-ahead or curve-fitting
+   than a genuine discovery.
+7. Promotion from provisional to permanent is a human gate. Do not automate it.
 
 **Failure modes specific to LLM-generated indicators:**
 
 - **Subtle look-ahead.** It is easy to write `df['close'].rolling(N).max()`
   thinking it's a backward window when in some libraries it isn't. The
-  validator catches the obvious cases. Read your own compute function
-  critically before registering.
+  validator does NOT yet catch look-ahead automatically — read your own
+  compute function critically before registering. Any use of `.shift(-N)`,
+  future prices, or non-causal rolling windows is disqualifying.
 - **Curve-fit by construction.** You can write an indicator that "predicts"
   the training set because you tuned its constants while looking at the
   chart. The permutation test catches this. Trust the test, not the chart.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,61 @@ Combine with a directional signal.
 
 ---
 
+## 3.1 Creating New Indicators
+
+You can register new indicators when the existing library doesn't fit the
+regime. This is a deliberate act, not a default move. Before creating one,
+you must justify why an existing indicator can't be adapted via parameters.
+
+**When creation is appropriate:**
+
+- The regime calls for a structurally distinct signal not in the library
+  (e.g., volatility breakout when only mean-reversion oscillators exist).
+- You can describe the edge in one sentence, same standard as any other
+  hypothesis.
+- The indicator is widely-recognised market microstructure logic (Keltner,
+  Donchian, Chaikin Money Flow), not a personally-invented composite.
+
+**When creation is not appropriate:**
+
+- You're stacking another filter onto a strategy that already underperforms.
+  Adding indicators is not how you fix a bad thesis.
+- The "new" indicator is a small variation on an existing one (different MA
+  type, different lookback). Use parameters, not a new spec.
+- You're searching for something that works. That's data mining. Discard
+  the hypothesis instead.
+
+**Procedure:**
+
+1. Generate a spec file matching the schema in `src/indicators/specs/`.
+2. Register it via the MCP tool. The registry validator runs automatically —
+   schema check, look-ahead check, determinism check.
+3. The new indicator is `provisional=True` until permutation-tested. It
+   cannot be used in a final recommendation until it passes p < 0.05 on
+   its own (not just as part of a strategy).
+4. Run the same characterize → baseline → diagnose loop on the new indicator
+   that you would on any existing one. The hard limit is still two entry
+   indicators per strategy.
+5. If the indicator survives permutation testing on multiple symbols/regimes,
+   propose promotion from `provisional=True` to permanent. Promotion is a
+   human gate.
+
+**Failure modes specific to LLM-generated indicators:**
+
+- **Subtle look-ahead.** It is easy to write `df['close'].rolling(N).max()`
+  thinking it's a backward window when in some libraries it isn't. The
+  validator catches the obvious cases. Read your own compute function
+  critically before registering.
+- **Curve-fit by construction.** You can write an indicator that "predicts"
+  the training set because you tuned its constants while looking at the
+  chart. The permutation test catches this. Trust the test, not the chart.
+- **Confirmation framing.** You'll be tempted to create an indicator that
+  confirms a hypothesis you've already committed to. Reverse the burden:
+  try to construct an indicator that invalidates your thesis. If you can't,
+  that's stronger evidence than confirmation.
+
+---
+
 ## 4. Baseline Backtest — Read It as a Diagnostic
 
 Run `run_backtest` with sensible default params. This is not pass/fail.
@@ -269,6 +324,9 @@ That is data mining disguised as research.
 - **Max drawdown < 5% with meaningful returns** — verify costs are applied.
 - **Profit factor > 4 with < 50 trades** — confidence interval, not edge.
 - **All P&L from a single regime window** — regime-specific, not structural.
+- **Provisional indicator with great backtest** — re-run with strict permutation.
+  New indicators have an inflated false-positive rate; treat their first good
+  result with extra skepticism.
 
 When something looks too good, it usually is. Say so.
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ APP := app.py
 STAMP := $(VENV)/.ready
 
 .DEFAULT_GOAL := run
-.PHONY: run clear
+.PHONY: run clear test regression
 
 $(STAMP): requirements.txt
 	@echo "Setting up virtual environment..."
@@ -18,6 +18,12 @@ $(STAMP): requirements.txt
 run: $(STAMP)
 	@echo "Starting Strategy Lab..."
 	@$(STREAMLIT) run $(APP)
+
+test: $(STAMP)
+	@$(VENV)/bin/python -m pytest tests/ -v
+
+regression: $(STAMP)
+	@$(VENV)/bin/python -m pytest tests/regression/ -v
 
 clear:
 	@echo "Removing $(VENV)..."

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ make test                                            # run unit tests
 
 All indicators off by default. Enable what you need in the sidebar.
 
+The canonical list of indicators and their parameters lives in `src/indicators/specs/`. Each file in that directory defines one `IndicatorSpec` — adding a new indicator means adding one file there and registering it in `src/indicators/specs/__init__.py`. See `docs/contributing/adding-an-indicator.md` for a step-by-step walkthrough.
+
 ## Backtest Engine
 
 Key execution rules:

--- a/docs/contributing/adding-an-indicator.md
+++ b/docs/contributing/adding-an-indicator.md
@@ -1,0 +1,132 @@
+# Adding a New Indicator
+
+Each indicator is a single file in `src/indicators/specs/`. Adding one means:
+
+1. Create the spec file
+2. Register it in `src/indicators/specs/__init__.py`
+3. Add its default params to `ui/session.py` → `get_default_params()`
+
+That's it. No if-else chains, no widget boilerplate, no optimizer blocks.
+
+---
+
+## Step 1 — Create the spec file
+
+Use `src/indicators/specs/rsi.py` as a template. Minimal structure:
+
+```python
+# src/indicators/specs/my_indicator.py
+"""My indicator entry spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+
+
+def compute_my_indicator(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    # Write output column(s) onto df. Receives ALL params.
+    df["my_col"] = ...
+    return df
+
+
+def long_signal_my_indicator(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["my_col"] > params["my_threshold"]
+
+
+def short_signal_my_indicator(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["my_col"] < params["my_threshold"]
+
+
+register(IndicatorSpec(
+    key="my_indicator",           # unique, snake_case
+    name="My Indicator",          # UI display name
+    group="entry",                # "entry", "exit", or "risk"
+    order=99,                     # ordering within the sidebar group
+    enable_param="my_indicator_enabled",
+    params=[
+        ParamSpec("my_indicator_enabled", "bool", False,
+                  optimize=False, label="My Indicator enabled", order=0),
+        ParamSpec("my_threshold", "int", 50, min=1, max=100,
+                  label="Threshold", order=1),
+    ],
+    compute=compute_my_indicator,
+    outputs=["my_col"],
+    long_signal=long_signal_my_indicator,
+    short_signal=short_signal_my_indicator,
+))
+```
+
+### Key fields
+
+| Field | Notes |
+|-------|-------|
+| `key` | Unique string. Used as the registry lookup key. |
+| `group` | `"entry"` → entry filter. `"exit"` → signal-based exit. `"risk"` → stop/TP/trailing. |
+| `enable_param` | Must match a `ParamSpec` with `type="bool"` and `optimize=False`. |
+| `outputs` | Column names your `compute` function writes to `df`. |
+| `long_signal` / `short_signal` | Return a boolean `pd.Series`. Set to `None` if the indicator doesn't generate that direction. |
+| `reuses_outputs_from` | List of other spec `key`s whose columns you read. Ensures topological order. |
+
+### `ParamSpec` fields
+
+| Field | Notes |
+|-------|-------|
+| `type` | `"int"`, `"float"`, `"categorical"`, `"bool"`. |
+| `min` / `max` | Required for numeric types. Also sets the Optuna search range. |
+| `step` | Optional. UI slider step (defaults: 1 for int, 0.5 for float). |
+| `choices` | Required for `"categorical"`. Use a `tuple` (hashable). |
+| `direction` | `"long"`, `"short"`, or `"both"`. Optimizer skips the param when the run direction doesn't match. |
+| `optimize` | `False` → param is never included in Optuna trials (use for enable toggles and display-only params). |
+| `label` | UI widget label. Falls back to `name` if empty. |
+| `order` | Widget ordering within the expander. |
+
+---
+
+## Step 2 — Register in `__init__.py`
+
+Open `src/indicators/specs/__init__.py` and import your new file:
+
+```python
+from . import my_indicator  # noqa: F401
+```
+
+The `register()` call at module level runs on import and appends your spec to `INDICATOR_REGISTRY`.
+
+---
+
+## Step 3 — Add defaults to `get_default_params()`
+
+Open `ui/session.py` and add your param defaults inside `get_default_params()`:
+
+```python
+'my_indicator_enabled': False,
+'my_threshold': 50,
+```
+
+This keeps the session state initialiser in sync for users whose cached state predates your indicator.
+
+---
+
+## What you get for free
+
+Once registered, the indicator is automatically wired into:
+
+- **Sidebar**: expander with widgets rendered by `render_indicator_section()`
+- **Signal pipeline**: `generate_entry_signals()` / `generate_exit_signals()` call your signal functions
+- **Optimizer**: `_build_params_from_trial()` includes your params in the Optuna search space
+- **Pin expander**: optimizable params appear in the "Pin Parameters" UI in the Optimize tab
+- **Active filters display**: your indicator's name appears in the active-filters caption when enabled
+
+---
+
+## Validation
+
+`validate_registry()` runs automatically at import time. It will raise `ValueError` if:
+
+- Your `key` is already taken
+- Any `param.name` conflicts with an existing param across the registry
+- `enable_param` is missing from `params` or is not `type="bool"`
+- A numeric param is missing `min` or `max`
+- A categorical param is missing `choices`
+- Any callable is a lambda (use named functions for picklability and debuggability)
+
+Run `python -c "from src.indicators.specs import *"` to trigger validation without starting the app.

--- a/src/indicators/registry.py
+++ b/src/indicators/registry.py
@@ -1,0 +1,222 @@
+"""
+Indicator Registry — single source of truth for all strategy indicators.
+
+Each indicator is described by an IndicatorSpec that carries its params,
+compute function, and signal callables. Consumers (calculate_indicators,
+generate_entry_signals, _build_params_from_trial, UI sidebar) iterate this
+registry instead of maintaining per-indicator if-else chains.
+
+Phase 1: schema + population only. No consumer changes yet.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+import pandas as pd
+
+# ─── Type aliases ─────────────────────────────────────────────────────────────
+
+ParamType = Literal["int", "float", "categorical", "bool"]
+Direction = Literal["long", "short", "both"]
+Group = Literal["entry", "exit", "risk", "core"]
+
+# Strategy-level params that live outside the indicator registry.
+# These are owned by StrategyParams itself, not by any IndicatorSpec.
+STRATEGY_LEVEL_PARAMS: frozenset = frozenset({
+    "trade_direction",
+    "entry_operator",
+    "exit_operator",
+    "allow_same_bar_exit",
+    "allow_same_bar_reversal",
+    "entry_conflict_mode",
+    "position_size_pct",
+    "use_kelly",
+    "kelly_fraction",
+})
+
+
+# ─── Schema ───────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """One tunable parameter owned by an indicator."""
+    name: str
+    type: ParamType
+    default: Any
+    min: Optional[float] = None          # numeric only
+    max: Optional[float] = None          # numeric only
+    step: Optional[float] = None         # UI step; 1 for int, 0.5 for float if None
+    choices: Optional[tuple] = None      # categorical only (use tuple for hashability)
+    direction: Direction = "both"        # limits optimizer suggestion to this direction
+    label: str = ""                      # UI label; falls back to name if empty
+    help: str = ""                       # UI tooltip
+    order: int = 0                       # UI ordering within indicator
+    optimize: bool = True                # False → never appears in Optuna search
+
+
+@dataclass
+class IndicatorSpec:
+    """One self-contained indicator declaration.
+
+    Treat as immutable after registration. Using a regular dataclass (not
+    frozen=True) because Callable fields are not hashable.
+    """
+    key: str                             # unique registry key, e.g. "rsi"
+    name: str                            # display name, e.g. "RSI"
+    group: Group                         # determines sidebar section + signal pipeline
+    order: int                           # UI ordering within group
+    enable_param: str                    # name of the bool ParamSpec that enables it
+    params: List[ParamSpec]              # all tunable params owned by this indicator
+    compute: Callable[[pd.DataFrame, Dict[str, Any]], pd.DataFrame]
+        # Pure function: (df, params_dict) → df with new columns added.
+        # Receives ALL params (registry-wide). Must not mutate df in-place on
+        # columns it doesn't own (use df = df.copy() selectively).
+    outputs: List[str]                   # column names this indicator writes to df
+
+    long_signal: Optional[Callable[[pd.DataFrame, Dict[str, Any]], pd.Series]] = None
+        # Returns boolean Series for long entry/exit. None = indicator doesn't
+        # contribute to long signals.
+    short_signal: Optional[Callable[[pd.DataFrame, Dict[str, Any]], pd.Series]] = None
+
+    reuses_outputs_from: List[str] = field(default_factory=list)
+        # Keys of other indicators whose outputs this one reads.
+        # Used for topological sort (dependency comes first) and dedup
+        # (if a dep is enabled, its compute already ran).
+        # Example: bbwp_exit reads the "bbwp" column from bbwp_entry.
+
+
+# ─── Global registry ──────────────────────────────────────────────────────────
+
+INDICATOR_REGISTRY: List[IndicatorSpec] = []
+_REGISTRY_INDEX: Dict[str, IndicatorSpec] = {}
+
+
+def register(spec: IndicatorSpec) -> None:
+    """Append a spec to the registry. Called at module import time by each spec file."""
+    INDICATOR_REGISTRY.append(spec)
+    _REGISTRY_INDEX[spec.key] = spec
+
+
+def get(key: str) -> IndicatorSpec:
+    """Return the spec for a given indicator key. Raises KeyError if not found."""
+    return _REGISTRY_INDEX[key]
+
+
+def all_specs() -> List[IndicatorSpec]:
+    """Return all registered specs in registration order."""
+    return list(INDICATOR_REGISTRY)
+
+
+def enabled_specs(params: Dict[str, Any]) -> List[IndicatorSpec]:
+    """Return specs whose enable_param is True in params."""
+    return [s for s in INDICATOR_REGISTRY if params.get(s.enable_param, False)]
+
+
+def build_defaults_from_registry() -> Dict[str, Any]:
+    """Build a flat dict of all indicator param defaults from the registry.
+
+    Does NOT include strategy-level params (trade_direction, etc.) — those are
+    seeded separately in StrategyParams.__init__.
+    """
+    defaults: Dict[str, Any] = {}
+    for spec in INDICATOR_REGISTRY:
+        for p in spec.params:
+            if p.name not in defaults:   # first registration wins
+                defaults[p.name] = p.default
+    return defaults
+
+
+# ─── Topological sort ─────────────────────────────────────────────────────────
+
+def topological_sort(specs: List[IndicatorSpec]) -> List[IndicatorSpec]:
+    """Sort specs so that dependencies (reuses_outputs_from) come before dependents.
+
+    Only specs present in the input list are considered; missing deps are skipped.
+    """
+    key_to_spec = {s.key: s for s in specs}
+    visited: set = set()
+    result: List[IndicatorSpec] = []
+
+    def visit(spec: IndicatorSpec) -> None:
+        if spec.key in visited:
+            return
+        for dep_key in spec.reuses_outputs_from:
+            if dep_key in key_to_spec:
+                visit(key_to_spec[dep_key])
+        visited.add(spec.key)
+        result.append(spec)
+
+    for spec in specs:
+        visit(spec)
+
+    return result
+
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+def validate_registry() -> None:
+    """Validate registry integrity. Called automatically at spec import time.
+
+    Raises ValueError on any violation.
+    """
+    seen_keys: set = set()
+    seen_param_names: set = set()
+
+    for spec in INDICATOR_REGISTRY:
+        # Duplicate indicator keys
+        if spec.key in seen_keys:
+            raise ValueError(f"Duplicate indicator key: '{spec.key}'")
+        seen_keys.add(spec.key)
+
+        # enable_param must exist in this spec's params as a bool
+        enable_param_found = False
+        for p in spec.params:
+            if p.name == spec.enable_param:
+                if p.type != "bool":
+                    raise ValueError(
+                        f"Indicator '{spec.key}': enable_param '{spec.enable_param}' "
+                        f"must have type='bool', got '{p.type}'"
+                    )
+                enable_param_found = True
+            # Duplicate param names across registry
+            if p.name in seen_param_names:
+                raise ValueError(
+                    f"Duplicate param name '{p.name}' (in indicator '{spec.key}')"
+                )
+            seen_param_names.add(p.name)
+
+            # Numeric params need min/max
+            if p.type in ("int", "float"):
+                if p.min is None or p.max is None:
+                    raise ValueError(
+                        f"Indicator '{spec.key}', param '{p.name}': "
+                        f"numeric params must have min and max"
+                    )
+            # Categorical params need choices
+            if p.type == "categorical":
+                if not p.choices:
+                    raise ValueError(
+                        f"Indicator '{spec.key}', param '{p.name}': "
+                        f"categorical params must have choices"
+                    )
+
+        if not enable_param_found:
+            raise ValueError(
+                f"Indicator '{spec.key}': enable_param '{spec.enable_param}' "
+                f"not found in spec.params"
+            )
+
+    # Callable names must not be lambdas
+    for spec in INDICATOR_REGISTRY:
+        for fn_name, fn in [
+            ("compute", spec.compute),
+            ("long_signal", spec.long_signal),
+            ("short_signal", spec.short_signal),
+        ]:
+            if fn is not None and fn.__name__.startswith("<lambda>"):
+                raise ValueError(
+                    f"Indicator '{spec.key}'.{fn_name} is a lambda — "
+                    "use a named function for debuggability and picklability"
+                )

--- a/src/indicators/registry.py
+++ b/src/indicators/registry.py
@@ -91,6 +91,7 @@ class IndicatorSpec:
 
 INDICATOR_REGISTRY: List[IndicatorSpec] = []
 _REGISTRY_INDEX: Dict[str, IndicatorSpec] = {}
+_PROVISIONAL_KEYS: set = set()  # keys of in-memory provisional indicators (restart clears)
 
 
 def register(spec: IndicatorSpec) -> None:

--- a/src/indicators/specs/__init__.py
+++ b/src/indicators/specs/__init__.py
@@ -1,0 +1,37 @@
+"""
+Import all indicator specs in explicit, deterministic order.
+
+Order matters for:
+1. Registry iteration (optimizer param ordering, UI sidebar ordering)
+2. Topological sort (dependencies must be importable before dependents)
+
+Do NOT replace with dynamic discovery (e.g. os.listdir) — that would make
+the order OS/filesystem-dependent and break Optuna trial reproducibility.
+"""
+# Entry group (order mirrors IndicatorSpec.order)
+from . import pamrp_entry    # order=1
+from . import bbwp_entry     # order=2
+from . import adx            # order=3
+from . import ma_trend       # order=4
+from . import rsi            # order=5
+from . import volume         # order=6
+from . import supertrend     # order=7
+from . import vwap           # order=8
+from . import macd           # order=9
+
+# Exit group
+from . import pamrp_exit     # order=1
+from . import stoch_rsi_exit # order=2
+from . import ma_exit        # order=3
+from . import bbwp_exit      # order=4
+
+# Risk group
+from . import stop_loss      # order=1
+from . import take_profit    # order=2
+from . import trailing_stop  # order=3
+from . import atr_trail      # order=4
+from . import time_exit      # order=5
+
+# Validate registry integrity at import time
+from ..registry import validate_registry
+validate_registry()

--- a/src/indicators/specs/adx.py
+++ b/src/indicators/specs/adx.py
@@ -1,0 +1,52 @@
+"""ADX trend-strength filter spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import adx as _adx
+
+
+def compute_adx(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["di_plus"], df["di_minus"], df["adx"] = _adx(
+        df["high"], df["low"], df["close"],
+        params["adx_length"], params["adx_smoothing"],
+    )
+    return df
+
+
+def long_signal_adx(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    mask = df["adx"] > params["adx_threshold"]
+    if params["adx_require_di"]:
+        mask = mask & (df["di_plus"] > df["di_minus"])
+    return mask
+
+
+def short_signal_adx(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    mask = df["adx"] > params["adx_threshold"]
+    if params["adx_require_di"]:
+        mask = mask & (df["di_minus"] > df["di_plus"])
+    return mask
+
+
+register(IndicatorSpec(
+    key="adx",
+    name="ADX",
+    group="entry",
+    order=3,
+    enable_param="adx_enabled",
+    params=[
+        ParamSpec("adx_enabled", "bool", False, optimize=False,
+                  label="ADX enabled", order=0),
+        ParamSpec("adx_length", "int", 14, min=1, max=50,
+                  label="Length", order=1),
+        ParamSpec("adx_smoothing", "int", 14, min=1, max=50,
+                  label="Smoothing", order=2),
+        ParamSpec("adx_threshold", "int", 20, min=1, max=99,
+                  label="Threshold", order=3),
+        ParamSpec("adx_require_di", "bool", False,
+                  label="Require DI alignment", order=4),
+    ],
+    compute=compute_adx,
+    outputs=["di_plus", "di_minus", "adx"],
+    long_signal=long_signal_adx,
+    short_signal=short_signal_adx,
+))

--- a/src/indicators/specs/atr_trail.py
+++ b/src/indicators/specs/atr_trail.py
@@ -1,0 +1,35 @@
+"""ATR-based trailing stop spec.
+
+Computes the 'atr' column used by the backtest engine for ATR trailing stops.
+No signal callables — engine handles the exit logic.
+"""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import atr as _atr
+
+
+def compute_atr_trail(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["atr"] = _atr(df["high"], df["low"], df["close"], params["atr_length"])
+    return df
+
+
+register(IndicatorSpec(
+    key="atr_trail",
+    name="ATR Trailing",
+    group="risk",
+    order=4,
+    enable_param="atr_trailing_enabled",
+    params=[
+        ParamSpec("atr_trailing_enabled", "bool", False, optimize=False,
+                  label="ATR trailing enabled", order=0),
+        ParamSpec("atr_length", "int", 14, min=1, max=50,
+                  label="ATR length", order=1),
+        ParamSpec("atr_multiplier", "float", 2.0, min=0.5, max=10.0, step=0.5,
+                  label="Multiplier", order=2),
+    ],
+    compute=compute_atr_trail,
+    outputs=["atr"],
+    long_signal=None,
+    short_signal=None,
+))

--- a/src/indicators/specs/bbwp_entry.py
+++ b/src/indicators/specs/bbwp_entry.py
@@ -1,0 +1,61 @@
+"""BBWP entry indicator spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import bbwp, sma
+
+
+def compute_bbwp_entry(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["bbwp"] = bbwp(df["close"], params["bbwp_length"], params["bbwp_lookback"])
+    df["bbwp_sma"] = sma(df["bbwp"], params["bbwp_sma_length"])
+    return df
+
+
+def long_signal_bbwp_entry(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    mask = df["bbwp"] < params["bbwp_threshold_long"]
+    filt = params["bbwp_ma_filter"]
+    if filt == "decreasing":
+        mask = mask & (df["bbwp_sma"] < df["bbwp_sma"].shift(1))
+    elif filt == "increasing":
+        mask = mask & (df["bbwp_sma"] > df["bbwp_sma"].shift(1))
+    return mask
+
+
+def short_signal_bbwp_entry(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    mask = df["bbwp"] > params["bbwp_threshold_short"]
+    filt = params["bbwp_ma_filter"]
+    if filt == "decreasing":
+        mask = mask & (df["bbwp_sma"] < df["bbwp_sma"].shift(1))
+    elif filt == "increasing":
+        mask = mask & (df["bbwp_sma"] > df["bbwp_sma"].shift(1))
+    return mask
+
+
+register(IndicatorSpec(
+    key="bbwp_entry",
+    name="BBWP",
+    group="entry",
+    order=2,
+    enable_param="bbwp_enabled",
+    params=[
+        ParamSpec("bbwp_enabled", "bool", True, optimize=False,
+                  label="BBWP enabled", order=0),
+        ParamSpec("bbwp_length", "int", 13, min=1, max=50,
+                  label="BB length", order=1),
+        ParamSpec("bbwp_lookback", "int", 252, min=50, max=500,
+                  label="Lookback", order=2),
+        ParamSpec("bbwp_sma_length", "int", 5, min=1, max=20,
+                  label="SMA length", order=3),
+        ParamSpec("bbwp_threshold_long", "int", 50, min=1, max=99,
+                  label="Long threshold", direction="long", order=4),
+        ParamSpec("bbwp_threshold_short", "int", 50, min=1, max=99,
+                  label="Short threshold", direction="short", order=5),
+        ParamSpec("bbwp_ma_filter", "categorical", "disabled",
+                  choices=("disabled", "decreasing", "increasing"),
+                  label="MA filter", order=6),
+    ],
+    compute=compute_bbwp_entry,
+    outputs=["bbwp", "bbwp_sma"],
+    long_signal=long_signal_bbwp_entry,
+    short_signal=short_signal_bbwp_entry,
+))

--- a/src/indicators/specs/bbwp_exit.py
+++ b/src/indicators/specs/bbwp_exit.py
@@ -1,0 +1,44 @@
+"""BBWP exit indicator spec.
+
+Reuses the 'bbwp' column computed by bbwp_entry. If bbwp_entry is disabled
+but bbwp_exit is enabled, this compute function computes bbwp itself.
+"""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import bbwp, sma
+
+
+def compute_bbwp_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    if "bbwp" not in df.columns:
+        df["bbwp"] = bbwp(df["close"], params["bbwp_length"], params["bbwp_lookback"])
+        df["bbwp_sma"] = sma(df["bbwp"], params["bbwp_sma_length"])
+    return df
+
+
+def long_signal_bbwp_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["bbwp"] > params["bbwp_exit_threshold"]
+
+
+def short_signal_bbwp_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["bbwp"] < params["bbwp_exit_threshold"]
+
+
+register(IndicatorSpec(
+    key="bbwp_exit",
+    name="BBWP Exit",
+    group="exit",
+    order=4,
+    enable_param="bbwp_exit_enabled",
+    params=[
+        ParamSpec("bbwp_exit_enabled", "bool", False, optimize=False,
+                  label="BBWP exit enabled", order=0),
+        ParamSpec("bbwp_exit_threshold", "int", 80, min=1, max=99,
+                  label="Exit threshold", order=1),
+    ],
+    compute=compute_bbwp_exit,
+    outputs=[],   # bbwp already written by bbwp_entry when both enabled
+    long_signal=long_signal_bbwp_exit,
+    short_signal=short_signal_bbwp_exit,
+    reuses_outputs_from=["bbwp_entry"],
+))

--- a/src/indicators/specs/ma_exit.py
+++ b/src/indicators/specs/ma_exit.py
@@ -1,0 +1,40 @@
+"""MA crossover exit spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import ema
+
+
+def compute_ma_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["exit_ma_fast"] = ema(df["close"], params["ma_exit_fast"])
+    df["exit_ma_slow"] = ema(df["close"], params["ma_exit_slow"])
+    return df
+
+
+def long_signal_ma_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["exit_ma_fast"] < df["exit_ma_slow"]
+
+
+def short_signal_ma_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["exit_ma_fast"] > df["exit_ma_slow"]
+
+
+register(IndicatorSpec(
+    key="ma_exit",
+    name="MA Exit",
+    group="exit",
+    order=3,
+    enable_param="ma_exit_enabled",
+    params=[
+        ParamSpec("ma_exit_enabled", "bool", False, optimize=False,
+                  label="MA exit enabled", order=0),
+        ParamSpec("ma_exit_fast", "int", 10, min=1, max=100,
+                  label="Fast EMA", order=1),
+        ParamSpec("ma_exit_slow", "int", 20, min=2, max=200,
+                  label="Slow EMA", order=2),
+    ],
+    compute=compute_ma_exit,
+    outputs=["exit_ma_fast", "exit_ma_slow"],
+    long_signal=long_signal_ma_exit,
+    short_signal=short_signal_ma_exit,
+))

--- a/src/indicators/specs/ma_trend.py
+++ b/src/indicators/specs/ma_trend.py
@@ -1,0 +1,43 @@
+"""MA Trend structural bias filter spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import ma
+
+
+def compute_ma_trend(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["ma_fast"] = ma(df["close"], params["ma_fast_length"], params["ma_type"])
+    df["ma_slow"] = ma(df["close"], params["ma_slow_length"], params["ma_type"])
+    return df
+
+
+def long_signal_ma_trend(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["ma_fast"] > df["ma_slow"]
+
+
+def short_signal_ma_trend(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["ma_fast"] < df["ma_slow"]
+
+
+register(IndicatorSpec(
+    key="ma_trend",
+    name="MA Trend",
+    group="entry",
+    order=4,
+    enable_param="ma_trend_enabled",
+    params=[
+        ParamSpec("ma_trend_enabled", "bool", False, optimize=False,
+                  label="MA Trend enabled", order=0),
+        ParamSpec("ma_fast_length", "int", 50, min=1, max=200,
+                  label="Fast MA length", order=1),
+        ParamSpec("ma_slow_length", "int", 200, min=2, max=500,
+                  label="Slow MA length", order=2),
+        ParamSpec("ma_type", "categorical", "sma",
+                  choices=("sma", "ema", "wma", "rma"),
+                  label="MA type", order=3),
+    ],
+    compute=compute_ma_trend,
+    outputs=["ma_fast", "ma_slow"],
+    long_signal=long_signal_ma_trend,
+    short_signal=short_signal_ma_trend,
+))

--- a/src/indicators/specs/macd.py
+++ b/src/indicators/specs/macd.py
@@ -1,0 +1,58 @@
+"""MACD momentum entry spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import macd as _macd
+
+
+def compute_macd(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["macd"], df["macd_signal"], df["macd_hist"] = _macd(
+        df["close"], params["macd_fast"], params["macd_slow"], params["macd_signal"],
+    )
+    return df
+
+
+def long_signal_macd(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    mode = params["macd_mode"]
+    if mode == "histogram":
+        return df["macd_hist"] > 0
+    elif mode == "crossover":
+        return df["macd"] > df["macd_signal"]
+    else:   # zero-line
+        return df["macd"] > 0
+
+
+def short_signal_macd(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    mode = params["macd_mode"]
+    if mode == "histogram":
+        return df["macd_hist"] < 0
+    elif mode == "crossover":
+        return df["macd"] < df["macd_signal"]
+    else:   # zero-line
+        return df["macd"] < 0
+
+
+register(IndicatorSpec(
+    key="macd",
+    name="MACD",
+    group="entry",
+    order=9,
+    enable_param="macd_enabled",
+    params=[
+        ParamSpec("macd_enabled", "bool", False, optimize=False,
+                  label="MACD enabled", order=0),
+        ParamSpec("macd_fast", "int", 12, min=1, max=100,
+                  label="Fast", order=1),
+        ParamSpec("macd_slow", "int", 26, min=2, max=200,
+                  label="Slow", order=2),
+        ParamSpec("macd_signal", "int", 9, min=1, max=50,
+                  label="Signal", order=3),
+        ParamSpec("macd_mode", "categorical", "histogram",
+                  choices=("histogram", "crossover", "zero-line"),
+                  label="Mode", order=4),
+    ],
+    compute=compute_macd,
+    outputs=["macd", "macd_signal", "macd_hist"],
+    long_signal=long_signal_macd,
+    short_signal=short_signal_macd,
+))

--- a/src/indicators/specs/pamrp_entry.py
+++ b/src/indicators/specs/pamrp_entry.py
@@ -1,0 +1,54 @@
+"""PAMRP entry indicator spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import pamrp
+
+
+def compute_pamrp_entry(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    vol = df["volume"] if "volume" in df.columns else None
+    df["pamrp_entry"] = pamrp(
+        df["close"],
+        params["pamrp_entry_ma_length"],
+        params["pamrp_entry_lookback"],
+        params["pamrp_entry_ma_type"],
+        vol,
+    )
+    df["pamrp"] = df["pamrp_entry"]   # legacy column kept for callers
+    return df
+
+
+def long_signal_pamrp_entry(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["pamrp_entry"] < params["pamrp_entry_long"]
+
+
+def short_signal_pamrp_entry(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["pamrp_entry"] > params["pamrp_entry_short"]
+
+
+register(IndicatorSpec(
+    key="pamrp_entry",
+    name="PAMRP",
+    group="entry",
+    order=1,
+    enable_param="pamrp_enabled",
+    params=[
+        ParamSpec("pamrp_enabled", "bool", True, optimize=False,
+                  label="PAMRP enabled", order=0),
+        ParamSpec("pamrp_entry_ma_length", "int", 20, min=1, max=200,
+                  label="MA length", order=1),
+        ParamSpec("pamrp_entry_lookback", "int", 350, min=50, max=1000,
+                  label="Lookback", order=2),
+        ParamSpec("pamrp_entry_ma_type", "categorical", "sma",
+                  choices=("sma", "ema", "wma", "rma"),
+                  label="MA type", order=3),
+        ParamSpec("pamrp_entry_long", "int", 20, min=1, max=49,
+                  label="Long threshold", direction="long", order=4),
+        ParamSpec("pamrp_entry_short", "int", 80, min=51, max=99,
+                  label="Short threshold", direction="short", order=5),
+    ],
+    compute=compute_pamrp_entry,
+    outputs=["pamrp_entry", "pamrp"],
+    long_signal=long_signal_pamrp_entry,
+    short_signal=short_signal_pamrp_entry,
+))

--- a/src/indicators/specs/pamrp_exit.py
+++ b/src/indicators/specs/pamrp_exit.py
@@ -1,0 +1,73 @@
+"""PAMRP exit indicator spec.
+
+PAMRP exit and entry share the same underlying computation but have
+independent parameters (MA length, lookback, MA type, thresholds).
+When params match and pamrp_entry was already computed, the exit reuses
+the pamrp_entry column to avoid redundant computation.
+"""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import pamrp
+
+
+def compute_pamrp_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    entry_reusable = (
+        params.get("pamrp_enabled", False)
+        and params["pamrp_exit_ma_length"] == params["pamrp_entry_ma_length"]
+        and params["pamrp_exit_lookback"] == params["pamrp_entry_lookback"]
+        and params["pamrp_exit_ma_type"] == params["pamrp_entry_ma_type"]
+        and "pamrp_entry" in df.columns
+    )
+    if entry_reusable:
+        df["pamrp_exit"] = df["pamrp_entry"]
+    else:
+        vol = df["volume"] if "volume" in df.columns else None
+        df["pamrp_exit"] = pamrp(
+            df["close"],
+            params["pamrp_exit_ma_length"],
+            params["pamrp_exit_lookback"],
+            params["pamrp_exit_ma_type"],
+            vol,
+        )
+        # Populate legacy pamrp column if entry didn't run
+        if "pamrp" not in df.columns:
+            df["pamrp"] = df["pamrp_exit"]
+    return df
+
+
+def long_signal_pamrp_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["pamrp_exit"] > params["pamrp_exit_long"]
+
+
+def short_signal_pamrp_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["pamrp_exit"] < params["pamrp_exit_short"]
+
+
+register(IndicatorSpec(
+    key="pamrp_exit",
+    name="PAMRP Exit",
+    group="exit",
+    order=1,
+    enable_param="pamrp_exit_enabled",
+    params=[
+        ParamSpec("pamrp_exit_enabled", "bool", True, optimize=False,
+                  label="PAMRP exit enabled", order=0),
+        ParamSpec("pamrp_exit_ma_length", "int", 20, min=1, max=200,
+                  label="MA length", order=1),
+        ParamSpec("pamrp_exit_lookback", "int", 350, min=50, max=1000,
+                  label="Lookback", order=2),
+        ParamSpec("pamrp_exit_ma_type", "categorical", "sma",
+                  choices=("sma", "ema", "wma", "rma"),
+                  label="MA type", order=3),
+        ParamSpec("pamrp_exit_long", "int", 70, min=51, max=99,
+                  label="Long exit threshold", direction="long", order=4),
+        ParamSpec("pamrp_exit_short", "int", 30, min=1, max=49,
+                  label="Short exit threshold", direction="short", order=5),
+    ],
+    compute=compute_pamrp_exit,
+    outputs=["pamrp_exit"],
+    long_signal=long_signal_pamrp_exit,
+    short_signal=short_signal_pamrp_exit,
+    reuses_outputs_from=["pamrp_entry"],
+))

--- a/src/indicators/specs/rsi.py
+++ b/src/indicators/specs/rsi.py
@@ -1,0 +1,41 @@
+"""RSI mean-reversion entry spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import rsi as _rsi
+
+
+def compute_rsi(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["rsi"] = _rsi(df["close"], params["rsi_length"])
+    return df
+
+
+def long_signal_rsi(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["rsi"] < params["rsi_oversold"]
+
+
+def short_signal_rsi(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["rsi"] > params["rsi_overbought"]
+
+
+register(IndicatorSpec(
+    key="rsi",
+    name="RSI",
+    group="entry",
+    order=5,
+    enable_param="rsi_enabled",
+    params=[
+        ParamSpec("rsi_enabled", "bool", False, optimize=False,
+                  label="RSI enabled", order=0),
+        ParamSpec("rsi_length", "int", 14, min=2, max=100,
+                  label="Length", order=1),
+        ParamSpec("rsi_oversold", "int", 30, min=1, max=49,
+                  label="Oversold", direction="long", order=2),
+        ParamSpec("rsi_overbought", "int", 70, min=51, max=99,
+                  label="Overbought", direction="short", order=3),
+    ],
+    compute=compute_rsi,
+    outputs=["rsi"],
+    long_signal=long_signal_rsi,
+    short_signal=short_signal_rsi,
+))

--- a/src/indicators/specs/stoch_rsi_exit.py
+++ b/src/indicators/specs/stoch_rsi_exit.py
@@ -1,0 +1,51 @@
+"""Stochastic RSI exit spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import stoch_rsi as _stoch_rsi
+
+
+def compute_stoch_rsi_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["stoch_k"], df["stoch_d"] = _stoch_rsi(
+        df["close"],
+        params["stoch_rsi_length"],   # rsi_length
+        params["stoch_rsi_length"],   # stoch_length — same param (FIX-SR)
+        params["stoch_rsi_k"],
+        params["stoch_rsi_d"],
+    )
+    return df
+
+
+def long_signal_stoch_rsi_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["stoch_k"] > params["stoch_rsi_overbought"]
+
+
+def short_signal_stoch_rsi_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["stoch_k"] < params["stoch_rsi_oversold"]
+
+
+register(IndicatorSpec(
+    key="stoch_rsi_exit",
+    name="Stoch RSI Exit",
+    group="exit",
+    order=2,
+    enable_param="stoch_rsi_exit_enabled",
+    params=[
+        ParamSpec("stoch_rsi_exit_enabled", "bool", False, optimize=False,
+                  label="Stoch RSI exit enabled", order=0),
+        ParamSpec("stoch_rsi_length", "int", 14, min=2, max=50,
+                  label="Length", order=1),
+        ParamSpec("stoch_rsi_k", "int", 3, min=1, max=20,
+                  label="%K smooth", order=2),
+        ParamSpec("stoch_rsi_d", "int", 3, min=1, max=20,
+                  label="%D smooth", order=3),
+        ParamSpec("stoch_rsi_overbought", "int", 80, min=51, max=99,
+                  label="Overbought", direction="long", order=4),
+        ParamSpec("stoch_rsi_oversold", "int", 20, min=1, max=49,
+                  label="Oversold", direction="short", order=5),
+    ],
+    compute=compute_stoch_rsi_exit,
+    outputs=["stoch_k", "stoch_d"],
+    long_signal=long_signal_stoch_rsi_exit,
+    short_signal=short_signal_stoch_rsi_exit,
+))

--- a/src/indicators/specs/stop_loss.py
+++ b/src/indicators/specs/stop_loss.py
@@ -1,0 +1,33 @@
+"""Stop loss risk spec.
+
+Params only — no compute columns, no signal callables.
+The backtest engine reads stop_loss_enabled / stop_loss_pct_* directly.
+"""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+
+
+def compute_stop_loss(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    return df
+
+
+register(IndicatorSpec(
+    key="stop_loss",
+    name="Stop Loss",
+    group="risk",
+    order=1,
+    enable_param="stop_loss_enabled",
+    params=[
+        ParamSpec("stop_loss_enabled", "bool", True, optimize=False,
+                  label="Stop loss enabled", order=0),
+        ParamSpec("stop_loss_pct_long", "float", 3.0, min=0.5, max=30.0, step=0.5,
+                  label="Long SL %", direction="long", order=1),
+        ParamSpec("stop_loss_pct_short", "float", 3.0, min=0.5, max=30.0, step=0.5,
+                  label="Short SL %", direction="short", order=2),
+    ],
+    compute=compute_stop_loss,
+    outputs=[],
+    long_signal=None,
+    short_signal=None,
+))

--- a/src/indicators/specs/supertrend.py
+++ b/src/indicators/specs/supertrend.py
@@ -1,0 +1,43 @@
+"""Supertrend ATR-based trend signal spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import supertrend as _supertrend
+
+
+def compute_supertrend(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    df["supertrend"], df["st_direction"] = _supertrend(
+        df["high"], df["low"], df["close"],
+        params["supertrend_period"], params["supertrend_multiplier"],
+    )
+    return df
+
+
+def long_signal_supertrend(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    # +1 = bullish (price above upper band), -1 = bearish
+    return df["st_direction"] > 0
+
+
+def short_signal_supertrend(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    return df["st_direction"] < 0
+
+
+register(IndicatorSpec(
+    key="supertrend",
+    name="Supertrend",
+    group="entry",
+    order=7,
+    enable_param="supertrend_enabled",
+    params=[
+        ParamSpec("supertrend_enabled", "bool", False, optimize=False,
+                  label="Supertrend enabled", order=0),
+        ParamSpec("supertrend_period", "int", 10, min=2, max=50,
+                  label="Period", order=1),
+        ParamSpec("supertrend_multiplier", "float", 3.0, min=0.5, max=10.0, step=0.5,
+                  label="Multiplier", order=2),
+    ],
+    compute=compute_supertrend,
+    outputs=["supertrend", "st_direction"],
+    long_signal=long_signal_supertrend,
+    short_signal=short_signal_supertrend,
+))

--- a/src/indicators/specs/take_profit.py
+++ b/src/indicators/specs/take_profit.py
@@ -1,0 +1,29 @@
+"""Take profit risk spec. Params only — engine handles execution."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+
+
+def compute_take_profit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    return df
+
+
+register(IndicatorSpec(
+    key="take_profit",
+    name="Take Profit",
+    group="risk",
+    order=2,
+    enable_param="take_profit_enabled",
+    params=[
+        ParamSpec("take_profit_enabled", "bool", False, optimize=False,
+                  label="Take profit enabled", order=0),
+        ParamSpec("take_profit_pct_long", "float", 5.0, min=0.5, max=50.0, step=0.5,
+                  label="Long TP %", direction="long", order=1),
+        ParamSpec("take_profit_pct_short", "float", 5.0, min=0.5, max=50.0, step=0.5,
+                  label="Short TP %", direction="short", order=2),
+    ],
+    compute=compute_take_profit,
+    outputs=[],
+    long_signal=None,
+    short_signal=None,
+))

--- a/src/indicators/specs/time_exit.py
+++ b/src/indicators/specs/time_exit.py
@@ -1,0 +1,29 @@
+"""Time exit spec. Params only — backtest engine executes the time-based exit."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+
+
+def compute_time_exit(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    return df
+
+
+register(IndicatorSpec(
+    key="time_exit",
+    name="Time Exit",
+    group="risk",
+    order=5,
+    enable_param="time_exit_enabled",
+    params=[
+        ParamSpec("time_exit_enabled", "bool", False, optimize=False,
+                  label="Time exit enabled", order=0),
+        ParamSpec("time_exit_bars_long", "int", 20, min=1, max=200,
+                  label="Long bars", direction="long", order=1),
+        ParamSpec("time_exit_bars_short", "int", 20, min=1, max=200,
+                  label="Short bars", direction="short", order=2),
+    ],
+    compute=compute_time_exit,
+    outputs=[],
+    long_signal=None,
+    short_signal=None,
+))

--- a/src/indicators/specs/trailing_stop.py
+++ b/src/indicators/specs/trailing_stop.py
@@ -1,0 +1,29 @@
+"""Trailing stop risk spec. Params only — engine handles execution."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+
+
+def compute_trailing_stop(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    return df
+
+
+register(IndicatorSpec(
+    key="trailing_stop",
+    name="Trailing Stop",
+    group="risk",
+    order=3,
+    enable_param="trailing_stop_enabled",
+    params=[
+        ParamSpec("trailing_stop_enabled", "bool", False, optimize=False,
+                  label="Trailing stop enabled", order=0),
+        ParamSpec("trailing_stop_pct", "float", 2.0, min=0.5, max=20.0, step=0.5,
+                  label="Trail %", order=1),
+        ParamSpec("trailing_stop_activation", "float", 1.0, min=0.0, max=10.0, step=0.5,
+                  label="Activation %", order=2),
+    ],
+    compute=compute_trailing_stop,
+    outputs=[],
+    long_signal=None,
+    short_signal=None,
+))

--- a/src/indicators/specs/volume.py
+++ b/src/indicators/specs/volume.py
@@ -1,0 +1,44 @@
+"""Volume participation confirmation spec."""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import sma
+
+
+def compute_volume(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    if "volume" in df.columns:
+        df["volume_ma"] = sma(df["volume"], params["volume_ma_length"])
+    return df
+
+
+def long_signal_volume(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    if "volume_ma" not in df.columns:
+        return pd.Series(False, index=df.index)
+    return df["volume"] > df["volume_ma"] * params["volume_multiplier"]
+
+
+def short_signal_volume(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+    if "volume_ma" not in df.columns:
+        return pd.Series(False, index=df.index)
+    return df["volume"] > df["volume_ma"] * params["volume_multiplier"]
+
+
+register(IndicatorSpec(
+    key="volume",
+    name="Volume",
+    group="entry",
+    order=6,
+    enable_param="volume_enabled",
+    params=[
+        ParamSpec("volume_enabled", "bool", False, optimize=False,
+                  label="Volume enabled", order=0),
+        ParamSpec("volume_ma_length", "int", 20, min=1, max=200,
+                  label="MA length", order=1),
+        ParamSpec("volume_multiplier", "float", 1.0, min=0.1, max=5.0, step=0.1,
+                  label="Multiplier", order=2),
+    ],
+    compute=compute_volume,
+    outputs=["volume_ma"],
+    long_signal=long_signal_volume,
+    short_signal=short_signal_volume,
+))

--- a/src/indicators/specs/vwap.py
+++ b/src/indicators/specs/vwap.py
@@ -1,0 +1,41 @@
+"""VWAP spec.
+
+VWAP is meaningful only for intraday data (price anchors to the session's
+value area). On daily OHLCV data it degenerates to a cumulative price-volume
+average with no session reset, producing a lagged trend-following signal
+rather than a true intraday mean-reversion anchor.
+
+For this reason long_signal and short_signal are set to None in the registry.
+The current strategy engine (src/strategy/__init__.py) does generate VWAP
+entry signals when vwap_enabled=True and the 'vwap' column is present, but
+this will not be wired into registry-driven signal generation in Phase 4.
+
+TODO: Revisit when intraday session-aware data loading is supported.
+"""
+from typing import Any, Dict
+import pandas as pd
+from ..registry import IndicatorSpec, ParamSpec, register
+from .. import vwap as _vwap
+
+
+def compute_vwap(df: pd.DataFrame, params: Dict[str, Any]) -> pd.DataFrame:
+    if "volume" in df.columns:
+        df["vwap"] = _vwap(df["high"], df["low"], df["close"], df["volume"])
+    return df
+
+
+register(IndicatorSpec(
+    key="vwap",
+    name="VWAP",
+    group="entry",
+    order=8,
+    enable_param="vwap_enabled",
+    params=[
+        ParamSpec("vwap_enabled", "bool", False, optimize=False,
+                  label="VWAP enabled", order=0),
+    ],
+    compute=compute_vwap,
+    outputs=["vwap"],
+    long_signal=None,
+    short_signal=None,
+))

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -32,6 +32,7 @@ Typical session flow:
 
 from __future__ import annotations
 
+import ast
 import math
 from datetime import date
 from pathlib import Path
@@ -43,8 +44,13 @@ import numpy as np
 from fastmcp import FastMCP
 
 from src.backtest import BacktestEngine, DEFAULT_COMMISSION_PCT, DEFAULT_SLIPPAGE_PCT
-from src.data import fetch_yfinance
+from src.data import fetch_yfinance, generate_sample_data as _generate_sample_data
 from src.indicators import adx as _adx, atr as _atr, sma as _sma
+import src.indicators as _ind_module
+from src.indicators.registry import (
+    INDICATOR_REGISTRY, IndicatorSpec, ParamSpec,
+    validate_registry as _validate_registry, _PROVISIONAL_KEYS,
+)
 from src.optimize import optimize_strategy
 from src.permutation import run_permutation_test as _run_permutation_test
 from ui.helpers import params_to_strategy
@@ -965,6 +971,168 @@ def get_research_history(
     entries = entries[:last_n]
 
     return {"status": "ok", "total": len(entries), "entries": entries}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Indicator registry tools
+# ─────────────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def list_indicators() -> Dict[str, Any]:
+    """
+    Returns all registered indicators — key, name, group, enabled status in
+    current params, and whether provisional.
+    Call this before creating an indicator to confirm it doesn't already exist.
+    """
+    indicators = []
+    for spec in INDICATOR_REGISTRY:
+        indicators.append({
+            "key":         spec.key,
+            "name":        spec.name,
+            "group":       spec.group,
+            "order":       spec.order,
+            "enabled":     bool(_state["params"].get(spec.enable_param, False)),
+            "provisional": spec.key in _PROVISIONAL_KEYS,
+            "params": [
+                {"name": p.name, "type": p.type, "default": p.default}
+                for p in spec.params
+            ],
+        })
+    return {"indicators": indicators, "count": len(indicators)}
+
+
+@mcp.tool()
+def register_indicator(spec_source: str) -> Dict[str, Any]:
+    """
+    Validates and registers a new indicator at runtime.
+
+    spec_source: complete Python source defining compute/signal functions and
+    calling register(IndicatorSpec(...)). Do NOT include import statements —
+    use pd, np, IndicatorSpec, ParamSpec, register, and any src.indicators
+    compute functions (sma, ema, rsi, atr, etc.) which are pre-loaded.
+
+    Validation (in order):
+    1. Syntax check
+    2. Import whitelist — pandas, numpy, scipy, src.indicators only
+    3. exec in restricted namespace — must call register(IndicatorSpec(...))
+    4. Duplicate key check
+    5. Schema validation via validate_registry()
+    6. Output column check on 100-bar synthetic data
+
+    On success: indicator is provisional, available immediately in set_params/run_backtest.
+    """
+    _ALLOWED_IMPORTS = {
+        "pandas", "numpy", "scipy", "scipy.stats",
+        "src.indicators", "src.indicators.registry",
+    }
+
+    # Step 1: syntax check
+    try:
+        compiled = compile(spec_source, "<mcp_indicator>", "exec")
+        tree = ast.parse(spec_source)
+    except SyntaxError as e:
+        return {"error": "syntax_error", "detail": str(e)}
+
+    # Step 2: import whitelist
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.name
+                if not any(name == a or name.startswith(a + ".") for a in _ALLOWED_IMPORTS):
+                    return {"error": "disallowed_import", "detail": name}
+        elif isinstance(node, ast.ImportFrom):
+            name = node.module or ""
+            if not any(name == a or name.startswith(a + ".") for a in _ALLOWED_IMPORTS):
+                return {"error": "disallowed_import", "detail": name}
+
+    # Step 3: exec in restricted namespace
+    _captured: List[Any] = []
+
+    def _capture_register(s: Any) -> None:
+        _captured.append(s)
+
+    _ind_fns = {
+        n: getattr(_ind_module, n)
+        for n in dir(_ind_module)
+        if not n.startswith("_")
+    }
+
+    namespace: Dict[str, Any] = {
+        "__builtins__": {
+            "len": len, "abs": abs, "round": round, "range": range,
+            "enumerate": enumerate, "zip": zip, "list": list, "dict": dict,
+            "tuple": tuple, "set": set, "float": float, "int": int,
+            "bool": bool, "str": str, "None": None, "True": True, "False": False,
+            "isinstance": isinstance, "getattr": getattr, "hasattr": hasattr,
+            "min": min, "max": max, "sum": sum, "print": print,
+        },
+        "pd":           pd,
+        "np":           np,
+        "IndicatorSpec": IndicatorSpec,
+        "ParamSpec":    ParamSpec,
+        "register":     _capture_register,
+        **_ind_fns,
+    }
+
+    try:
+        exec(compiled, namespace)
+    except Exception as e:
+        return {"error": "exec_error", "detail": str(e)}
+
+    spec = _captured[0] if _captured else namespace.get("spec")
+    if spec is None:
+        return {
+            "error": "no_spec_produced",
+            "detail": "Source must call register(IndicatorSpec(...)) or assign result to 'spec'",
+        }
+    if not isinstance(spec, IndicatorSpec):
+        return {
+            "error": "no_spec_produced",
+            "detail": f"Expected IndicatorSpec, got {type(spec).__name__}",
+        }
+
+    # Step 4: duplicate key check
+    if any(s.key == spec.key for s in INDICATOR_REGISTRY):
+        return {"error": "duplicate_key", "detail": spec.key}
+
+    # Step 5: schema validation (append temporarily, validate, rollback on failure)
+    INDICATOR_REGISTRY.append(spec)
+    try:
+        _validate_registry()
+    except ValueError as e:
+        INDICATOR_REGISTRY.pop()
+        return {"error": "schema_error", "detail": str(e)}
+
+    # Step 6: output column check
+    try:
+        test_df = _generate_sample_data(days=100, seed=0)
+        defaults = {p.name: p.default for p in spec.params}
+        result_df = spec.compute(test_df.copy(), defaults)
+        missing = [col for col in spec.outputs if col not in result_df.columns]
+        if missing:
+            INDICATOR_REGISTRY.pop()
+            return {"error": "output_columns_missing", "detail": missing}
+    except Exception as e:
+        INDICATOR_REGISTRY.pop()
+        return {"error": "compute_error", "detail": str(e)}
+
+    # Registration complete — mark provisional and seed defaults into state
+    _PROVISIONAL_KEYS.add(spec.key)
+    for p in spec.params:
+        if p.name not in _state["params"]:
+            _state["params"][p.name] = p.default
+
+    return {
+        "status":      "ok",
+        "key":         spec.key,
+        "name":        spec.name,
+        "group":       spec.group,
+        "provisional": True,
+        "params": [
+            {"name": p.name, "type": p.type, "default": p.default}
+            for p in spec.params
+        ],
+    }
+
 
 if __name__ == "__main__":
     mcp.run()  # defaults to stdio transport — required for Claude Desktop

--- a/src/optimize/__init__.py
+++ b/src/optimize/__init__.py
@@ -23,6 +23,8 @@ except ImportError:
     raise ImportError("Install optuna: pip install optuna")
 
 from ..strategy import StrategyParams, TradeDirection, ConditionOperator, EntryConflictMode
+from ..indicators.registry import INDICATOR_REGISTRY
+from ..indicators import specs as _indicator_specs  # noqa: F401 — triggers registration
 from ..backtest import (
     BacktestEngine,
     BacktestResults,
@@ -47,30 +49,17 @@ def _suppress_warnings():
 # Parameter classification
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Entry-signal params — instability HERE means no reliable edge
-_ENTRY_PARAM_PREFIXES = (
-    'pamrp_entry_ma_length', 'pamrp_entry_lookback', 'pamrp_entry_ma_type', 'pamrp_entry',
-    'bbwp_length', 'bbwp_lookback', 'bbwp_sma', 'bbwp_threshold', 'bbwp_ma',
-    'adx_length', 'adx_smoothing', 'adx_threshold',
-    'ma_fast_length', 'ma_slow_length', 'ma_type',
-    'rsi_length', 'rsi_oversold', 'rsi_overbought',
-    'volume_ma_length', 'volume_multiplier',
-    'supertrend_period', 'supertrend_multiplier',
-    'macd_fast', 'macd_slow', 'macd_signal',
-)
-
-# Exit/risk params — adapting between regimes is EXPECTED, not a red flag
-_EXIT_PARAM_PREFIXES = (
-    'pamrp_exit_ma_length', 'pamrp_exit_lookback', 'pamrp_exit_ma_type',
-    'stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct',
-    'atr_length', 'atr_multiplier',
-    'time_exit_bars', 'ma_exit_fast', 'ma_exit_slow',
-    'bbwp_exit_threshold', 'pamrp_exit',
+# Entry-signal params — instability HERE means no reliable edge.
+# Derived from the registry: any param owned by a spec with group="entry".
+_ENTRY_PARAM_NAMES: frozenset = frozenset(
+    p.name
+    for spec in INDICATOR_REGISTRY if spec.group == "entry"
+    for p in spec.params
 )
 
 
 def _is_entry_param(name: str) -> bool:
-    return any(name.startswith(p) for p in _ENTRY_PARAM_PREFIXES)
+    return name in _ENTRY_PARAM_NAMES
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -158,49 +147,38 @@ class OptimizationResult:
 def _count_active_params(
     enabled_filters: Dict[str, bool],
     pinned_params: Optional[Dict[str, Any]] = None,
+    trade_direction: TradeDirection = TradeDirection.BOTH,
 ) -> int:
     """
-    Estimate numeric parameters that will be optimized.
-    Each enabled indicator contributes an approximate dimension count.
-    Pinned params are subtracted — they consume no trial dimensions.
+    Count parameters that will be optimized via Optuna for the given config.
+    Derived from the registry — no hardcoded dim counts needed.
+    Pinned params are subtracted; direction-only params are skipped when
+    the trade direction makes them irrelevant.
     """
-    dims_per_indicator = {
-        'pamrp_enabled': 4,
-        'bbwp_enabled': 6,
-        'adx_enabled': 3,
-        'ma_trend_enabled': 3,
-        'rsi_enabled': 3,
-        'volume_enabled': 2,
-        'supertrend_enabled': 2,
-        'vwap_enabled': 0,
-        'macd_enabled': 3,
-        'stop_loss_enabled': 2,
-        'take_profit_enabled': 2,
-        'trailing_stop_enabled': 1,
-        'atr_trailing_enabled': 2,
-        'time_exit_enabled': 1,
-        'ma_exit_enabled': 2,
-        'bbwp_exit_enabled': 1,
-        'pamrp_exit_enabled': 3,
-        'stoch_rsi_exit_enabled': 0,
-    }
-    total = sum(
-        dims_per_indicator.get(k, 2)
-        for k, v in enabled_filters.items() if v
-    )
-    # Each pinned param removes one dimension from the search space
+    long_or_both  = trade_direction in (TradeDirection.LONG_ONLY,  TradeDirection.BOTH)
+    short_or_both = trade_direction in (TradeDirection.SHORT_ONLY, TradeDirection.BOTH)
+    total = 0
+    for spec in INDICATOR_REGISTRY:
+        if not enabled_filters.get(spec.enable_param, False):
+            continue
+        for p in spec.params:
+            if not p.optimize:
+                continue
+            if p.direction == "long"  and not long_or_both:
+                continue
+            if p.direction == "short" and not short_or_both:
+                continue
+            total += 1
     n_pinned = len(pinned_params) if pinned_params else 0
     return max(total - n_pinned, 1)
 
 
 def _count_enabled_indicators(enabled_filters: Dict[str, bool]) -> int:
-    """Count distinct entry-filter indicators only."""
-    entry_keys = {
-        'pamrp_enabled', 'bbwp_enabled', 'adx_enabled', 'ma_trend_enabled',
-        'rsi_enabled', 'volume_enabled', 'supertrend_enabled', 'vwap_enabled',
-        'macd_enabled',
-    }
-    return sum(1 for k, v in enabled_filters.items() if k in entry_keys and v)
+    """Count distinct entry-group indicators that are enabled."""
+    return sum(
+        1 for spec in INDICATOR_REGISTRY
+        if spec.group == "entry" and enabled_filters.get(spec.enable_param, False)
+    )
 
 
 def _build_trial_budget_warnings(
@@ -453,163 +431,70 @@ class BayesianOptimizer:
 
     def _build_params_from_trial(self, trial) -> StrategyParams:
         """
-        Build StrategyParams from an Optuna trial.
+        Build StrategyParams from an Optuna trial using the indicator registry.
 
-        For each parameter, if it is listed in self.pinned_params, its pinned
-        value is used directly without calling trial.suggest_*.  This removes
-        the parameter from the search space, reducing effective dimensionality
-        and improving TPE convergence for the remaining free params.
+        For each enabled spec, each optimizable ParamSpec is suggested via Optuna
+        (subject to pinning and direction filtering). Disabled specs use registry
+        defaults. Strategy-level params come from pinned_params or class defaults.
         """
-        pp = self.pinned_params  # dict of {param_name: fixed_value}
-
-        def p_operator(name: str, default: ConditionOperator) -> ConditionOperator:
-            value = pp.get(name, default)
-            if isinstance(value, ConditionOperator):
-                return value
-            if isinstance(value, str):
-                return ConditionOperator(value.lower())
-            return default
-
-        def p_entry_conflict_mode(name: str, default: EntryConflictMode) -> EntryConflictMode:
-            value = pp.get(name, default)
-            if isinstance(value, EntryConflictMode):
-                return value
-            if isinstance(value, str):
-                return EntryConflictMode(value.lower())
-            return default
-
-        def p_bool(name: str, default: bool) -> bool:
-            value = pp.get(name, default)
-            if isinstance(value, str):
-                return value.lower() in {'1', 'true', 'yes', 'on'}
-            return bool(value)
-
-        # Local helpers — check pin first, fall back to Optuna suggest
-        def p_int(name: str, lo: int, hi: int) -> int:
-            return int(pp[name]) if name in pp else trial.suggest_int(name, lo, hi)
-
-        def p_float(name: str, lo: float, hi: float) -> float:
-            return float(pp[name]) if name in pp else trial.suggest_float(name, lo, hi)
-
-        def p_cat(name: str, choices: list):
-            return pp[name] if name in pp else trial.suggest_categorical(name, choices)
-
+        pp = self.pinned_params
         ef = self.enabled_filters
-        long_or_both  = self.trade_direction in [TradeDirection.LONG_ONLY,  TradeDirection.BOTH]
-        short_or_both = self.trade_direction in [TradeDirection.SHORT_ONLY, TradeDirection.BOTH]
+        long_or_both  = self.trade_direction in (TradeDirection.LONG_ONLY,  TradeDirection.BOTH)
+        short_or_both = self.trade_direction in (TradeDirection.SHORT_ONLY, TradeDirection.BOTH)
 
-        pe    = ef.get('pamrp_enabled', False)
-        pe_ml = p_int('pamrp_entry_ma_length', 10, 50) if pe else 20
-        pe_lb = p_int('pamrp_entry_lookback', 100, 500) if pe else 350
-        pe_mt = p_cat('pamrp_entry_ma_type', ['sma', 'ema', 'wma', 'rma']) if pe else 'sma'
-        pel   = p_int('pamrp_entry_long', 10, 40) if pe and long_or_both else 20
-        pes   = p_int('pamrp_entry_short', 60, 95) if pe and short_or_both else 80
+        params_dict: Dict[str, Any] = {}
 
-        pxe   = ef.get('pamrp_exit_enabled', False)
-        px_ml = p_int('pamrp_exit_ma_length', 10, 50) if pxe else 20
-        px_lb = p_int('pamrp_exit_lookback', 100, 500) if pxe else 350
-        px_mt = p_cat('pamrp_exit_ma_type', ['sma', 'ema', 'wma', 'rma']) if pxe else 'sma'
-        pxl   = p_int('pamrp_exit_long', 55, 90) if pxe and long_or_both else 70
-        pxs   = p_int('pamrp_exit_short', 10, 45) if pxe and short_or_both else 30
+        for spec in INDICATOR_REGISTRY:
+            enabled = ef.get(spec.enable_param, False)
+            for param in spec.params:
+                # Direction-only params: skip suggest when direction doesn't apply
+                if param.direction == "long"  and not long_or_both:
+                    params_dict[param.name] = param.default
+                    continue
+                if param.direction == "short" and not short_or_both:
+                    params_dict[param.name] = param.default
+                    continue
+                # Pinned: use fixed value, don't consume a trial dimension
+                if param.name in pp:
+                    params_dict[param.name] = pp[param.name]
+                    continue
+                # Disabled spec or non-optimizable param: use registry default
+                if not enabled or not param.optimize:
+                    params_dict[param.name] = param.default
+                    continue
+                # Suggest from trial
+                if param.type == "int":
+                    params_dict[param.name] = trial.suggest_int(
+                        param.name, int(param.min), int(param.max)
+                    )
+                elif param.type == "float":
+                    params_dict[param.name] = trial.suggest_float(
+                        param.name, float(param.min), float(param.max)
+                    )
+                elif param.type == "categorical":
+                    params_dict[param.name] = trial.suggest_categorical(
+                        param.name, list(param.choices)
+                    )
+                else:
+                    params_dict[param.name] = param.default
 
-        be   = ef.get('bbwp_enabled', True)
-        bl   = p_int('bbwp_length',         8,   21) if be else 13
-        blb  = p_int('bbwp_lookback',      50,  1000) if be else 252
-        bsma = p_int('bbwp_sma_length',     3,   10) if be else 5
-        bmf  = p_cat('bbwp_ma_filter', ['disabled', 'decreasing']) if be else 'disabled'
-        btl  = p_int('bbwp_threshold_long',  30,  70) if be and long_or_both  else 50
-        bts  = p_int('bbwp_threshold_short', 30,  70) if be and short_or_both else 50
+        # Strategy-level params: always from pinned or class defaults (not registry)
+        params_dict["trade_direction"] = self.trade_direction
+        for name in ("entry_operator", "exit_operator", "allow_same_bar_exit",
+                     "allow_same_bar_reversal", "entry_conflict_mode"):
+            if name in pp:
+                params_dict[name] = pp[name]
 
-        ae  = ef.get('adx_enabled', False)
-        al  = p_int('adx_length',    10, 20) if ae else 14
-        asm = p_int('adx_smoothing', 10, 20) if ae else 14
-        at  = p_int('adx_threshold', 15, 60) if ae else 20
-
-        mae = ef.get('ma_trend_enabled', False)
-        maf = p_int('ma_fast_length',  20, 500) if mae else 50
-        mas = p_int('ma_slow_length', 100, 1000) if mae else 200
-        mat = p_cat('ma_type', ['sma', 'ema'])  if mae else 'sma'
-
-        re  = ef.get('rsi_enabled', False)
-        rl  = p_int('rsi_length',    7,  21) if re else 14
-        ros = p_int('rsi_oversold',  20, 40) if re else 30
-        rob = p_int('rsi_overbought', 60, 80) if re else 70
-
-        ve  = ef.get('volume_enabled', False)
-        vml = p_int('volume_ma_length',  10,  30) if ve else 20
-        vm  = p_float('volume_multiplier', 0.8, 1.5) if ve else 1.0
-
-        ste = ef.get('supertrend_enabled', False)
-        stp = p_int('supertrend_period',         7,  100) if ste else 10
-        stm = p_float('supertrend_multiplier', 1.5, 10.0) if ste else 3.0
-
-        vwe = ef.get('vwap_enabled', False)
-
-        mce  = ef.get('macd_enabled', False)
-        mcf  = p_int('macd_fast',    8,  15) if mce else 12
-        mcs  = p_int('macd_slow',   20,  30) if mce else 26
-        mcsi = p_int('macd_signal',  6,  12) if mce else 9
-
-        sle = ef.get('stop_loss_enabled', True)
-        sll = p_float('stop_loss_pct_long',  0.5, 30.0) if sle else 3.0
-        sls = p_float('stop_loss_pct_short', 0.5, 30.0) if sle else 3.0
-
-        tpe = ef.get('take_profit_enabled', False)
-        tpl = p_float('take_profit_pct_long',  1.0, 50.0) if tpe else 5.0
-        tps = p_float('take_profit_pct_short', 1.0, 50.0) if tpe else 5.0
-
-        tse = ef.get('trailing_stop_enabled', False)
-        tsp = p_float('trailing_stop_pct', 1.0, 5.0) if tse else 2.0
-
-        ate = ef.get('atr_trailing_enabled', False)
-        atl = p_int('atr_length',         10,  20) if ate else 14
-        atm = p_float('atr_multiplier', 1.5, 4.0) if ate else 2.0
-   
-        sre = ef.get('stoch_rsi_exit_enabled', False)
-
-        txe = ef.get('time_exit_enabled', False)
-        txb = p_int('time_exit_bars', 10, 50) if txe else 20
-
-        mxe = ef.get('ma_exit_enabled', False)
-        mxf = p_int('ma_exit_fast',  5, 15) if mxe else 10
-        mxs = p_int('ma_exit_slow', 15, 30) if mxe else 20
-
-        bxe = ef.get('bbwp_exit_enabled', False)
-        bxt = p_int('bbwp_exit_threshold', 70, 90) if bxe else 80
-
-        has_exit = any([sle, tpe, tse, ate, pxe, sre, txe, mxe, bxe])
-        if not has_exit:
-            pxe = True
-
-        return StrategyParams(
-            trade_direction=self.trade_direction,
-            entry_operator=p_operator('entry_operator', ConditionOperator.AND),
-            exit_operator=p_operator('exit_operator', ConditionOperator.OR),
-            allow_same_bar_exit=p_bool('allow_same_bar_exit', True),
-            allow_same_bar_reversal=p_bool('allow_same_bar_reversal', False),
-            entry_conflict_mode=p_entry_conflict_mode('entry_conflict_mode', EntryConflictMode.SKIP),
-            pamrp_enabled=pe,
-            pamrp_entry_ma_length=pe_ml, pamrp_entry_lookback=pe_lb, pamrp_entry_ma_type=pe_mt,
-            pamrp_entry_long=pel, pamrp_entry_short=pes,
-            pamrp_exit_ma_length=px_ml, pamrp_exit_lookback=px_lb, pamrp_exit_ma_type=px_mt,
-            pamrp_exit_long=pxl, pamrp_exit_short=pxs,
-            bbwp_enabled=be, bbwp_length=bl, bbwp_lookback=blb, bbwp_sma_length=bsma,
-            bbwp_threshold_long=btl, bbwp_threshold_short=bts, bbwp_ma_filter=bmf,
-            adx_enabled=ae, adx_length=al, adx_smoothing=asm, adx_threshold=at,
-            ma_trend_enabled=mae, ma_fast_length=maf, ma_slow_length=mas, ma_type=mat,
-            rsi_enabled=re, rsi_length=rl, rsi_oversold=ros, rsi_overbought=rob,
-            volume_enabled=ve, volume_ma_length=vml, volume_multiplier=vm,
-            supertrend_enabled=ste, supertrend_period=stp, supertrend_multiplier=stm,
-            vwap_enabled=vwe, macd_enabled=mce, macd_fast=mcf, macd_slow=mcs, macd_signal=mcsi,
-            stop_loss_enabled=sle, stop_loss_pct_long=sll, stop_loss_pct_short=sls,
-            take_profit_enabled=tpe, take_profit_pct_long=tpl, take_profit_pct_short=tps,
-            trailing_stop_enabled=tse, trailing_stop_pct=tsp,
-            atr_trailing_enabled=ate, atr_length=atl, atr_multiplier=atm,
-            pamrp_exit_enabled=pxe, stoch_rsi_exit_enabled=sre,
-            time_exit_enabled=txe, time_exit_bars_long=txb, time_exit_bars_short=txb,
-            ma_exit_enabled=mxe, ma_exit_fast=mxf, ma_exit_slow=mxs,
-            bbwp_exit_enabled=bxe, bbwp_exit_threshold=bxt,
+        # Ensure at least one exit is active
+        has_exit = any(
+            ef.get(spec.enable_param, False)
+            for spec in INDICATOR_REGISTRY
+            if spec.group in ("exit", "risk")
         )
+        if not has_exit:
+            params_dict["pamrp_exit_enabled"] = True
+
+        return StrategyParams.from_dict(params_dict)
 
     # ── Optuna study runner ───────────────────────────────────────────────────
 

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -22,10 +22,6 @@ import pandas as pd
 from typing import Dict, Any, Iterable
 from enum import Enum
 
-from ..indicators import (
-    pamrp, bbwp, sma, ema, rsi, stoch_rsi, adx, atr,
-    supertrend, vwap, macd, ma
-)
 from ..indicators.registry import (
     enabled_specs, topological_sort, build_defaults_from_registry,
 )
@@ -184,82 +180,29 @@ class SignalGenerator:
 
     def generate_entry_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
-        p  = self.params
+        p = self.params
+        params = p.to_dict()
+        td = p.trade_direction
+        long_or_both  = td in (TradeDirection.LONG_ONLY,  TradeDirection.BOTH)
+        short_or_both = td in (TradeDirection.SHORT_ONLY, TradeDirection.BOTH)
 
-        long_masks: list[pd.Series] = []
+        long_masks:  list[pd.Series] = []
         short_masks: list[pd.Series] = []
 
-        if p.pamrp_enabled:
-            long_masks.append(df['pamrp_entry'] < p.pamrp_entry_long)
-            short_masks.append(df['pamrp_entry'] > p.pamrp_entry_short)
+        for spec in enabled_specs(params):
+            if spec.group != "entry":
+                continue
+            if long_or_both and spec.long_signal is not None:
+                long_masks.append(spec.long_signal(df, params))
+            if short_or_both and spec.short_signal is not None:
+                short_masks.append(spec.short_signal(df, params))
 
-        if p.bbwp_enabled:
-            long_mask = df['bbwp'] < p.bbwp_threshold_long
-            short_mask = df['bbwp'] > p.bbwp_threshold_short
-
-            if p.bbwp_ma_filter == 'decreasing':
-                bbwp_ma_ok   = df['bbwp_sma'] < df['bbwp_sma'].shift(1)
-                long_mask = long_mask & bbwp_ma_ok
-                short_mask = short_mask & bbwp_ma_ok
-            elif p.bbwp_ma_filter == 'increasing':
-                bbwp_ma_ok   = df['bbwp_sma'] > df['bbwp_sma'].shift(1)
-                long_mask = long_mask & bbwp_ma_ok
-                short_mask = short_mask & bbwp_ma_ok
-
-            long_masks.append(long_mask)
-            short_masks.append(short_mask)
-
-        if p.adx_enabled and 'adx' in df.columns:
-            long_mask = df['adx'] > p.adx_threshold
-            short_mask = long_mask
-            if p.adx_require_di:
-                long_mask = long_mask & (df['di_plus'] > df['di_minus'])
-                short_mask = short_mask & (df['di_minus'] > df['di_plus'])
-            long_masks.append(long_mask)
-            short_masks.append(short_mask)
-
-        if p.ma_trend_enabled and 'ma_fast' in df.columns:
-            long_masks.append(df['ma_fast'] > df['ma_slow'])
-            short_masks.append(df['ma_fast'] < df['ma_slow'])
-
-        if p.rsi_enabled and 'rsi' in df.columns:
-            long_masks.append(df['rsi'] < p.rsi_oversold)
-            short_masks.append(df['rsi'] > p.rsi_overbought)
-
-        if p.volume_enabled and 'volume_ma' in df.columns:
-            vol_ok = df['volume'] > df['volume_ma'] * p.volume_multiplier
-            long_masks.append(vol_ok)
-            short_masks.append(vol_ok)
-
-        if p.supertrend_enabled and 'st_direction' in df.columns:
-            # [FIX-ST] Corrected convention: +1 = bullish, -1 = bearish
-            # Old code (wrong): st_direction < 0 for long, > 0 for short
-            long_masks.append(df['st_direction'] > 0)
-            short_masks.append(df['st_direction'] < 0)
-
-        if p.vwap_enabled and 'vwap' in df.columns:
-            long_masks.append(df['close'] > df['vwap'])
-            short_masks.append(df['close'] < df['vwap'])
-
-        if p.macd_enabled and 'macd_hist' in df.columns:
-            if p.macd_mode == 'histogram':
-                long_mask = df['macd_hist'] > 0
-                short_mask = df['macd_hist'] < 0
-            elif p.macd_mode == 'crossover':
-                long_mask = df['macd'] > df['macd_signal']
-                short_mask = df['macd'] < df['macd_signal']
-            else:  # zero-line
-                long_mask = df['macd'] > 0
-                short_mask = df['macd'] < 0
-            long_masks.append(long_mask)
-            short_masks.append(short_mask)
-
-        long_signal = self._combine_condition_masks(long_masks, p.entry_operator, df.index)
+        long_signal  = self._combine_condition_masks(long_masks,  p.entry_operator, df.index)
         short_signal = self._combine_condition_masks(short_masks, p.entry_operator, df.index)
 
-        if p.trade_direction == TradeDirection.LONG_ONLY:
+        if td == TradeDirection.LONG_ONLY:
             short_signal = pd.Series(False, index=df.index)
-        elif p.trade_direction == TradeDirection.SHORT_ONLY:
+        elif td == TradeDirection.SHORT_ONLY:
             long_signal  = pd.Series(False, index=df.index)
 
         df['entry_long']  = long_signal.fillna(False)
@@ -269,28 +212,21 @@ class SignalGenerator:
 
     def generate_exit_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
-        p  = self.params
+        p = self.params
+        params = p.to_dict()
 
-        exit_long_masks: list[pd.Series] = []
+        exit_long_masks:  list[pd.Series] = []
         exit_short_masks: list[pd.Series] = []
 
-        if p.pamrp_exit_enabled:
-            exit_long_masks.append(df['pamrp_exit'] > p.pamrp_exit_long)
-            exit_short_masks.append(df['pamrp_exit'] < p.pamrp_exit_short)
+        for spec in enabled_specs(params):
+            if spec.group != "exit":
+                continue
+            if spec.long_signal is not None:
+                exit_long_masks.append(spec.long_signal(df, params))
+            if spec.short_signal is not None:
+                exit_short_masks.append(spec.short_signal(df, params))
 
-        if p.stoch_rsi_exit_enabled and 'stoch_k' in df.columns:
-            exit_long_masks.append(df['stoch_k'] > p.stoch_rsi_overbought)
-            exit_short_masks.append(df['stoch_k'] < p.stoch_rsi_oversold)
-
-        if p.ma_exit_enabled and 'exit_ma_fast' in df.columns:
-            exit_long_masks.append(df['exit_ma_fast'] < df['exit_ma_slow'])
-            exit_short_masks.append(df['exit_ma_fast'] > df['exit_ma_slow'])
-
-        if p.bbwp_exit_enabled and 'bbwp' in df.columns:
-            exit_long_masks.append(df['bbwp'] > p.bbwp_exit_threshold)
-            exit_short_masks.append(df['bbwp'] < p.bbwp_exit_threshold)
-
-        exit_long = self._combine_condition_masks(exit_long_masks, p.exit_operator, df.index)
+        exit_long  = self._combine_condition_masks(exit_long_masks,  p.exit_operator, df.index)
         exit_short = self._combine_condition_masks(exit_short_masks, p.exit_operator, df.index)
 
         df['exit_long_signal']  = exit_long.fillna(False)

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -27,6 +27,8 @@ from ..indicators import (
     pamrp, bbwp, sma, ema, rsi, stoch_rsi, adx, atr,
     supertrend, vwap, macd, ma
 )
+from ..indicators.registry import enabled_specs, topological_sort
+from ..indicators import specs as _indicator_specs  # noqa: F401 — triggers registration
 
 
 class TradeDirection(Enum):
@@ -230,108 +232,24 @@ class SignalGenerator:
 
     def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
-        p  = self.params
+        params = self.params.to_dict()
 
-        # PAMRP entry/exit can use independent MA window, lookback, and MA type.
-        vol = df['volume'] if 'volume' in df.columns else None
-        if p.pamrp_enabled:
-            df['pamrp_entry'] = pamrp(
-                df['close'], p.pamrp_entry_ma_length, p.pamrp_entry_lookback,
-                p.pamrp_entry_ma_type, vol,
-            )
-        else:
+        for spec in topological_sort(enabled_specs(params)):
+            df = spec.compute(df, params)
+
+        # Legacy fallback columns: signal generation guards access with
+        # if p.X_enabled, so these don't affect trades, but external
+        # callers may expect them.
+        if 'pamrp_entry' not in df.columns:
             df['pamrp_entry'] = 50.0
-
-        if p.pamrp_exit_enabled:
-            entry_reusable = (
-                p.pamrp_enabled
-                and p.pamrp_exit_ma_length == p.pamrp_entry_ma_length
-                and p.pamrp_exit_lookback  == p.pamrp_entry_lookback
-                and p.pamrp_exit_ma_type   == p.pamrp_entry_ma_type
-            )
-            if entry_reusable:
-                df['pamrp_exit'] = df['pamrp_entry']
-            else:
-                df['pamrp_exit'] = pamrp(
-                    df['close'], p.pamrp_exit_ma_length, p.pamrp_exit_lookback,
-                    p.pamrp_exit_ma_type, vol,
-                )
-        else:
+        if 'pamrp_exit' not in df.columns:
             df['pamrp_exit'] = 50.0
-
-        # Keep the legacy column for callers that still expect one PAMRP series.
-        if p.pamrp_enabled:
-            df['pamrp'] = df['pamrp_entry']
-        elif p.pamrp_exit_enabled:
-            df['pamrp'] = df['pamrp_exit']
-        else:
+        if 'pamrp' not in df.columns:
             df['pamrp'] = 50.0
-
-        # BBWP
-        if p.bbwp_enabled or p.bbwp_exit_enabled:
-            df['bbwp']     = bbwp(df['close'], p.bbwp_length, p.bbwp_lookback)
-            df['bbwp_sma'] = sma(df['bbwp'], p.bbwp_sma_length)
-        else:
-            df['bbwp']     = 50.0
+        if 'bbwp' not in df.columns:
+            df['bbwp'] = 50.0
+        if 'bbwp_sma' not in df.columns:
             df['bbwp_sma'] = 50.0
-
-        # ADX
-        if p.adx_enabled:
-            df['di_plus'], df['di_minus'], df['adx'] = adx(
-                df['high'], df['low'], df['close'], p.adx_length, p.adx_smoothing
-            )
-
-        # MA Trend
-        if p.ma_trend_enabled:
-            df['ma_fast'] = ma(df['close'], p.ma_fast_length, p.ma_type)
-            df['ma_slow'] = ma(df['close'], p.ma_slow_length, p.ma_type)
-
-        # RSI
-        if p.rsi_enabled:
-            df['rsi'] = rsi(df['close'], p.rsi_length)
-
-        # Stoch RSI
-        # [FIX-SR] stoch_length added as explicit second argument.
-        # Defaults to stoch_rsi_length (same value) — no behaviour change
-        # for existing configs. Expose a separate UI param in the future if needed.
-        if p.stoch_rsi_exit_enabled:
-            df['stoch_k'], df['stoch_d'] = stoch_rsi(
-                df['close'],
-                p.stoch_rsi_length,   # rsi_length
-                p.stoch_rsi_length,   # stoch_length  ← [FIX-SR]
-                p.stoch_rsi_k,
-                p.stoch_rsi_d,
-            )
-
-        # Volume
-        if p.volume_enabled and 'volume' in df.columns:
-            df['volume_ma'] = sma(df['volume'], p.volume_ma_length)
-
-        # Supertrend
-        if p.supertrend_enabled:
-            df['supertrend'], df['st_direction'] = supertrend(
-                df['high'], df['low'], df['close'],
-                p.supertrend_period, p.supertrend_multiplier
-            )
-
-        # VWAP
-        if p.vwap_enabled and 'volume' in df.columns:
-            df['vwap'] = vwap(df['high'], df['low'], df['close'], df['volume'])
-
-        # MACD
-        if p.macd_enabled:
-            df['macd'], df['macd_signal'], df['macd_hist'] = macd(
-                df['close'], p.macd_fast, p.macd_slow, p.macd_signal
-            )
-
-        # ATR (for trailing stop)
-        if p.atr_trailing_enabled:
-            df['atr'] = atr(df['high'], df['low'], df['close'], p.atr_length)
-
-        # MA Exit
-        if p.ma_exit_enabled:
-            df['exit_ma_fast'] = ema(df['close'], p.ma_exit_fast)
-            df['exit_ma_slow'] = ema(df['close'], p.ma_exit_slow)
 
         return df
 

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -19,7 +19,6 @@ Changes from previous version
 """
 
 import pandas as pd
-from dataclasses import dataclass
 from typing import Dict, Any, Iterable
 from enum import Enum
 
@@ -27,7 +26,9 @@ from ..indicators import (
     pamrp, bbwp, sma, ema, rsi, stoch_rsi, adx, atr,
     supertrend, vwap, macd, ma
 )
-from ..indicators.registry import enabled_specs, topological_sort
+from ..indicators.registry import (
+    enabled_specs, topological_sort, build_defaults_from_registry,
+)
 from ..indicators import specs as _indicator_specs  # noqa: F401 — triggers registration
 
 
@@ -48,159 +49,87 @@ class EntryConflictMode(str, Enum):
     PREFER_SHORT = "prefer_short"
 
 
-@dataclass
+_STRATEGY_LEVEL_DEFAULTS: Dict[str, Any] = {
+    "trade_direction":        TradeDirection.LONG_ONLY,
+    "entry_operator":         ConditionOperator.AND,
+    "exit_operator":          ConditionOperator.OR,
+    "allow_same_bar_exit":    True,
+    "allow_same_bar_reversal": False,
+    "entry_conflict_mode":    EntryConflictMode.SKIP,
+    "position_size_pct":      100.0,
+    "use_kelly":              False,
+    "kelly_fraction":         0.5,
+}
+
+_DIRECTION_MAP: Dict[str, TradeDirection] = {
+    "Long Only":  TradeDirection.LONG_ONLY,
+    "Short Only": TradeDirection.SHORT_ONLY,
+    "Both":       TradeDirection.BOTH,
+    "long_only":  TradeDirection.LONG_ONLY,
+    "short_only": TradeDirection.SHORT_ONLY,
+    "both":       TradeDirection.BOTH,
+}
+
+
 class StrategyParams:
-    """All strategy parameters — fully exposed."""
+    """Dict-backed param container. Attribute-access shim keeps call sites unchanged."""
 
-    trade_direction: TradeDirection = TradeDirection.LONG_ONLY
-    entry_operator: ConditionOperator = ConditionOperator.AND
-    exit_operator: ConditionOperator = ConditionOperator.OR
-    allow_same_bar_exit: bool = True
-    allow_same_bar_reversal: bool = False
-    entry_conflict_mode: EntryConflictMode = EntryConflictMode.SKIP
+    def __init__(self, **overrides: Any) -> None:
+        d: Dict[str, Any] = {**_STRATEGY_LEVEL_DEFAULTS, **build_defaults_from_registry()}
+        d.update(overrides)
+        object.__setattr__(self, "_d", d)
 
-    # Position Sizing
-    position_size_pct: float = 100.0
-    use_kelly: bool = False
-    kelly_fraction: float = 0.5
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return object.__getattribute__(self, "_d")[name]
+        except KeyError:
+            raise AttributeError(f"StrategyParams has no attribute '{name}'")
 
-    # PAMRP
-    pamrp_enabled: bool = True
-    pamrp_entry_ma_length: int = 20
-    pamrp_entry_lookback: int = 350
-    pamrp_entry_ma_type: str = 'sma'
-    pamrp_entry_long: int = 20
-    pamrp_entry_short: int = 80
-    pamrp_exit_ma_length: int = 20
-    pamrp_exit_lookback: int = 350
-    pamrp_exit_ma_type: str = 'sma'
-    pamrp_exit_long: int = 70
-    pamrp_exit_short: int = 30
-
-    # BBWP
-    bbwp_enabled: bool = True
-    bbwp_length: int = 13
-    bbwp_lookback: int = 252
-    bbwp_sma_length: int = 5
-    bbwp_threshold_long: int = 50
-    bbwp_threshold_short: int = 50
-    bbwp_ma_filter: str = "disabled"
-
-    # ADX
-    adx_enabled: bool = False
-    adx_length: int = 14
-    adx_smoothing: int = 14
-    adx_threshold: int = 20
-    adx_require_di: bool = False
-
-    # MA Trend
-    ma_trend_enabled: bool = False
-    ma_fast_length: int = 50
-    ma_slow_length: int = 200
-    ma_type: str = "sma"
-
-    # RSI
-    rsi_enabled: bool = False
-    rsi_length: int = 14
-    rsi_oversold: int = 30
-    rsi_overbought: int = 70
-
-    # Volume
-    volume_enabled: bool = False
-    volume_ma_length: int = 20
-    volume_multiplier: float = 1.0
-
-    # Supertrend
-    supertrend_enabled: bool = False
-    supertrend_period: int = 10
-    supertrend_multiplier: float = 3.0
-
-    # VWAP
-    vwap_enabled: bool = False
-
-    # MACD
-    macd_enabled: bool = False
-    macd_fast: int = 12
-    macd_slow: int = 26
-    macd_signal: int = 9
-    macd_mode: str = "histogram"
-
-    # Stop Loss
-    stop_loss_enabled: bool = True
-    stop_loss_pct_long: float = 3.0
-    stop_loss_pct_short: float = 3.0
-
-    # Take Profit
-    take_profit_enabled: bool = False
-    take_profit_pct_long: float = 5.0
-    take_profit_pct_short: float = 5.0
-
-    # Trailing Stop
-    trailing_stop_enabled: bool = False
-    trailing_stop_pct: float = 2.0
-    trailing_stop_activation: float = 1.0
-
-    # ATR Trailing
-    atr_trailing_enabled: bool = False
-    atr_length: int = 14
-    atr_multiplier: float = 2.0
-
-    # PAMRP Exit
-    pamrp_exit_enabled: bool = True
-
-    # Stoch RSI Exit
-    stoch_rsi_exit_enabled: bool = False
-    stoch_rsi_length: int = 14
-    stoch_rsi_k: int = 3
-    stoch_rsi_d: int = 3
-    stoch_rsi_overbought: int = 80
-    stoch_rsi_oversold: int = 20
-
-    # Time Exit
-    time_exit_enabled: bool = False
-    time_exit_bars_long: int = 20
-    time_exit_bars_short: int = 20
-
-    # MA Exit
-    ma_exit_enabled: bool = False
-    ma_exit_fast: int = 10
-    ma_exit_slow: int = 20
-
-    # BBWP Exit
-    bbwp_exit_enabled: bool = False
-    bbwp_exit_threshold: int = 80
+    def __setattr__(self, name: str, value: Any) -> None:
+        object.__getattribute__(self, "_d")[name] = value
 
     def to_dict(self) -> Dict[str, Any]:
         result = {}
-        for k, v in self.__dict__.items():
+        for k, v in object.__getattribute__(self, "_d").items():
             result[k] = v.value if isinstance(v, Enum) else v
         return result
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> 'StrategyParams':
-        d = d.copy()
-        if 'trade_direction' in d and isinstance(d['trade_direction'], str):
-            d['trade_direction'] = TradeDirection(d['trade_direction'])
-        if 'entry_operator' in d and isinstance(d['entry_operator'], str):
-            d['entry_operator'] = ConditionOperator(d['entry_operator'].lower())
-        if 'exit_operator' in d and isinstance(d['exit_operator'], str):
-            d['exit_operator'] = ConditionOperator(d['exit_operator'].lower())
-        if 'entry_conflict_mode' in d and isinstance(d['entry_conflict_mode'], str):
-            d['entry_conflict_mode'] = EntryConflictMode(d['entry_conflict_mode'].lower())
-        # Layer 1: pamrp_length → entry/exit split (oldest sessions)
-        legacy_pamrp_length = d.pop('pamrp_length', None)
+    def from_dict(cls, d: Dict[str, Any]) -> "StrategyParams":
+        d = dict(d)
+        # PAMRP migration layer 1: pamrp_length → entry/exit split
+        legacy_pamrp_length = d.pop("pamrp_length", None)
         if legacy_pamrp_length is not None:
-            d.setdefault('pamrp_entry_length', legacy_pamrp_length)
-            d.setdefault('pamrp_exit_length', legacy_pamrp_length)
-        # Layer 2: pamrp_entry_length / pamrp_exit_length → ma_length (pre-FIX-11 sessions)
-        legacy_entry_length = d.pop('pamrp_entry_length', None)
+            d.setdefault("pamrp_entry_length", legacy_pamrp_length)
+            d.setdefault("pamrp_exit_length", legacy_pamrp_length)
+        # PAMRP migration layer 2: pamrp_entry/exit_length → ma_length
+        legacy_entry_length = d.pop("pamrp_entry_length", None)
         if legacy_entry_length is not None:
-            d.setdefault('pamrp_entry_ma_length', legacy_entry_length)
-        legacy_exit_length = d.pop('pamrp_exit_length', None)
+            d.setdefault("pamrp_entry_ma_length", legacy_entry_length)
+        legacy_exit_length = d.pop("pamrp_exit_length", None)
         if legacy_exit_length is not None:
-            d.setdefault('pamrp_exit_ma_length', legacy_exit_length)
-        valid_fields = set(cls.__dataclass_fields__.keys())
-        return cls(**{k: v for k, v in d.items() if k in valid_fields})
+            d.setdefault("pamrp_exit_ma_length", legacy_exit_length)
+        # UI migration: time_exit_bars (single) → long/short split
+        legacy_bars = d.pop("time_exit_bars", None)
+        if legacy_bars is not None:
+            d.setdefault("time_exit_bars_long", legacy_bars)
+            d.setdefault("time_exit_bars_short", legacy_bars)
+        # Enum coercions (handles both UI display strings and storage values)
+        td = d.get("trade_direction")
+        if isinstance(td, str):
+            d["trade_direction"] = _DIRECTION_MAP.get(td, TradeDirection.LONG_ONLY)
+        eo = d.get("entry_operator")
+        if isinstance(eo, str):
+            d["entry_operator"] = ConditionOperator(eo.lower())
+        xo = d.get("exit_operator")
+        if isinstance(xo, str):
+            d["exit_operator"] = ConditionOperator(xo.lower())
+        ecm = d.get("entry_conflict_mode")
+        if isinstance(ecm, str):
+            d["entry_conflict_mode"] = EntryConflictMode(ecm.lower())
+        # Filter to known keys only
+        known = set(_STRATEGY_LEVEL_DEFAULTS) | set(build_defaults_from_registry())
+        return cls(**{k: v for k, v in d.items() if k in known})
 
 
 class SignalGenerator:

--- a/tests/regression/configs.py
+++ b/tests/regression/configs.py
@@ -1,0 +1,235 @@
+"""
+Five reference backtest configurations that pin behavioral snapshots.
+
+Each entry: (config_name, params_dict, fixture_filename)
+
+StrategyParams defaults to watch out for:
+    pamrp_enabled=True, bbwp_enabled=True, stop_loss_enabled=True,
+    pamrp_exit_enabled=True — must be explicitly overridden when not wanted.
+
+Fixtures 1/2/4/5 use real yfinance daily data (committed as parquet).
+Fixture 3 (ETH-USD 1h style) uses synthetic generate_sample_data output
+because yfinance limits 1h data to ~730 calendar days of rolling history.
+"""
+
+CONFIGS = [
+    (
+        "pamrp_long_spy",
+        {
+            "trade_direction": "long_only",
+            "entry_operator": "and",
+            "exit_operator": "or",
+            # PAMRP entry on
+            "pamrp_enabled": True,
+            "pamrp_entry_ma_length": 20,
+            "pamrp_entry_lookback": 350,
+            "pamrp_entry_ma_type": "sma",
+            "pamrp_entry_long": 20,
+            "pamrp_entry_short": 80,
+            # PAMRP exit on
+            "pamrp_exit_enabled": True,
+            "pamrp_exit_ma_length": 20,
+            "pamrp_exit_lookback": 350,
+            "pamrp_exit_ma_type": "sma",
+            "pamrp_exit_long": 70,
+            "pamrp_exit_short": 30,
+            # Stop loss (default exits)
+            "stop_loss_enabled": True,
+            "stop_loss_pct_long": 3.0,
+            # Disable all others
+            "bbwp_enabled": False,
+            "adx_enabled": False,
+            "ma_trend_enabled": False,
+            "rsi_enabled": False,
+            "volume_enabled": False,
+            "supertrend_enabled": False,
+            "vwap_enabled": False,
+            "macd_enabled": False,
+            "take_profit_enabled": False,
+            "trailing_stop_enabled": False,
+            "atr_trailing_enabled": False,
+            "stoch_rsi_exit_enabled": False,
+            "time_exit_enabled": False,
+            "ma_exit_enabled": False,
+            "bbwp_exit_enabled": False,
+        },
+        "spy_1d_2020_2024.parquet",
+    ),
+    (
+        "pamrp_bbwp_long_qqq",
+        {
+            "trade_direction": "long_only",
+            "entry_operator": "and",
+            "exit_operator": "or",
+            # PAMRP entry on
+            "pamrp_enabled": True,
+            "pamrp_entry_ma_length": 20,
+            "pamrp_entry_lookback": 252,
+            "pamrp_entry_ma_type": "sma",
+            "pamrp_entry_long": 20,
+            # PAMRP exit on
+            "pamrp_exit_enabled": True,
+            "pamrp_exit_ma_length": 20,
+            "pamrp_exit_lookback": 252,
+            "pamrp_exit_ma_type": "sma",
+            "pamrp_exit_long": 70,
+            # BBWP entry filter on
+            "bbwp_enabled": True,
+            "bbwp_length": 13,
+            "bbwp_lookback": 252,
+            "bbwp_sma_length": 5,
+            "bbwp_threshold_long": 50,
+            "bbwp_ma_filter": "disabled",
+            # Stop loss + Take profit
+            "stop_loss_enabled": True,
+            "stop_loss_pct_long": 3.0,
+            "take_profit_enabled": True,
+            "take_profit_pct_long": 5.0,
+            # Disable others
+            "adx_enabled": False,
+            "ma_trend_enabled": False,
+            "rsi_enabled": False,
+            "volume_enabled": False,
+            "supertrend_enabled": False,
+            "vwap_enabled": False,
+            "macd_enabled": False,
+            "trailing_stop_enabled": False,
+            "atr_trailing_enabled": False,
+            "stoch_rsi_exit_enabled": False,
+            "time_exit_enabled": False,
+            "ma_exit_enabled": False,
+            "bbwp_exit_enabled": False,
+        },
+        "qqq_1d_2018_2024.parquet",
+    ),
+    (
+        "rsi_both_eth_trailing",
+        {
+            "trade_direction": "both",
+            "entry_operator": "and",
+            "exit_operator": "or",
+            "entry_conflict_mode": "skip",
+            # RSI mean-reversion
+            "rsi_enabled": True,
+            "rsi_length": 14,
+            "rsi_oversold": 30,
+            "rsi_overbought": 70,
+            # Trailing stop + hard SL backup (prevents open-ended positions
+            # on a downtrending synthetic asset where activation never fires)
+            "stop_loss_enabled": True,
+            "stop_loss_pct_long": 8.0,
+            "stop_loss_pct_short": 8.0,
+            "trailing_stop_enabled": True,
+            "trailing_stop_pct": 3.0,
+            "trailing_stop_activation": 1.0,
+            # No PAMRP
+            "pamrp_enabled": False,
+            "pamrp_exit_enabled": False,
+            # Disable others
+            "bbwp_enabled": False,
+            "adx_enabled": False,
+            "ma_trend_enabled": False,
+            "volume_enabled": False,
+            "supertrend_enabled": False,
+            "vwap_enabled": False,
+            "macd_enabled": False,
+            "take_profit_enabled": False,
+            "atr_trailing_enabled": False,
+            "stoch_rsi_exit_enabled": False,
+            "time_exit_enabled": False,
+            "ma_exit_enabled": False,
+            "bbwp_exit_enabled": False,
+        },
+        # SYNTHETIC — yfinance 1h data is limited to ~730 rolling calendar days,
+        # making the fixture non-reproducible across time. Using generate_sample_data
+        # with seed=7, vol=0.025, drift=0.0002 to simulate a crypto-like asset.
+        "eth_1h_synthetic.parquet",
+    ),
+    (
+        "adx_matrend_long_aapl_timeexit",
+        {
+            "trade_direction": "long_only",
+            "entry_operator": "and",
+            "exit_operator": "or",
+            # ADX trend-strength filter
+            "adx_enabled": True,
+            "adx_length": 14,
+            "adx_smoothing": 14,
+            "adx_threshold": 20,
+            "adx_require_di": True,
+            # MA trend direction filter
+            "ma_trend_enabled": True,
+            "ma_fast_length": 50,
+            "ma_slow_length": 200,
+            "ma_type": "sma",
+            # Time exit
+            "time_exit_enabled": True,
+            "time_exit_bars_long": 20,
+            # No signal-based exits, no fixed SL
+            "stop_loss_enabled": False,
+            "pamrp_exit_enabled": False,
+            # Disable others
+            "pamrp_enabled": False,
+            "bbwp_enabled": False,
+            "rsi_enabled": False,
+            "volume_enabled": False,
+            "supertrend_enabled": False,
+            "vwap_enabled": False,
+            "macd_enabled": False,
+            "take_profit_enabled": False,
+            "trailing_stop_enabled": False,
+            "atr_trailing_enabled": False,
+            "stoch_rsi_exit_enabled": False,
+            "ma_exit_enabled": False,
+            "bbwp_exit_enabled": False,
+        },
+        "aapl_1d_2015_2024.parquet",
+    ),
+    (
+        "macd_volume_both_tsla_pamrpexit",
+        {
+            "trade_direction": "both",
+            "entry_operator": "and",
+            "exit_operator": "or",
+            "entry_conflict_mode": "skip",
+            # MACD signal
+            "macd_enabled": True,
+            "macd_fast": 12,
+            "macd_slow": 26,
+            "macd_signal": 9,
+            "macd_mode": "histogram",
+            # Volume confirmation
+            "volume_enabled": True,
+            "volume_ma_length": 20,
+            "volume_multiplier": 1.0,
+            # Stop loss
+            "stop_loss_enabled": True,
+            "stop_loss_pct_long": 3.0,
+            "stop_loss_pct_short": 3.0,
+            # PAMRP exit
+            "pamrp_exit_enabled": True,
+            "pamrp_exit_ma_length": 20,
+            "pamrp_exit_lookback": 252,
+            "pamrp_exit_ma_type": "sma",
+            "pamrp_exit_long": 70,
+            "pamrp_exit_short": 30,
+            # No PAMRP entry
+            "pamrp_enabled": False,
+            # Disable others
+            "bbwp_enabled": False,
+            "adx_enabled": False,
+            "ma_trend_enabled": False,
+            "rsi_enabled": False,
+            "supertrend_enabled": False,
+            "vwap_enabled": False,
+            "take_profit_enabled": False,
+            "trailing_stop_enabled": False,
+            "atr_trailing_enabled": False,
+            "stoch_rsi_exit_enabled": False,
+            "time_exit_enabled": False,
+            "ma_exit_enabled": False,
+            "bbwp_exit_enabled": False,
+        },
+        "tsla_1d_2020_2024.parquet",
+    ),
+]

--- a/tests/regression/expected_hashes.json
+++ b/tests/regression/expected_hashes.json
@@ -1,0 +1,7 @@
+{
+  "pamrp_long_spy": "bbbb5c19a6eaa73b7099febf6da6b12e534f8fd2eda23d7ceb828662ddd75636",
+  "pamrp_bbwp_long_qqq": "1dd15a932eb24350b64a7612d41f02655a1d93aaaf404379c1025989812cb144",
+  "rsi_both_eth_trailing": "63756e8f5b0a633cc855e72be4b91b93f6bbf2646bb0a4b4d9d7689bc08cd168",
+  "adx_matrend_long_aapl_timeexit": "b6cafb7da588b9af91f41a70e707560d04c30d0bc2f903c2f5d83b04f686543b",
+  "macd_volume_both_tsla_pamrpexit": "633e9ccd4aacff0c72728451117cee20774819cc5cba03d123bbafd008ec8866"
+}

--- a/tests/regression/generate_fixtures.py
+++ b/tests/regression/generate_fixtures.py
@@ -1,0 +1,68 @@
+"""
+Generate (or regenerate) regression fixture parquet files.
+
+Run once before the first regression test run:
+    python -m tests.regression.generate_fixtures
+
+Uses yfinance for daily data. Config 3 (ETH-USD 1h) uses synthetic data
+because yfinance 1h history is limited to ~730 rolling calendar days
+and would produce a non-reproducible fixture.
+"""
+import sys
+from pathlib import Path
+
+# Allow running from project root: python -m tests.regression.generate_fixtures
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+from src.data import fetch_yfinance, generate_sample_data
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+FIXTURE_DIR.mkdir(exist_ok=True)
+
+
+def _save(df: pd.DataFrame, filename: str) -> None:
+    path = FIXTURE_DIR / filename
+    df.to_parquet(path)
+    print(f"  saved {filename}  ({len(df)} bars)")
+
+
+def generate_all() -> None:
+    print("Generating regression fixtures...\n")
+
+    # ── Fixture 1: SPY daily 2020-2024 ────────────────────────────────────────
+    print("1. SPY 1d 2020-01-01 → 2024-12-31")
+    df = fetch_yfinance("SPY", "2020-01-01", "2024-12-31", "1d")
+    _save(df, "spy_1d_2020_2024.parquet")
+
+    # ── Fixture 2: QQQ daily 2018-2024 ────────────────────────────────────────
+    print("2. QQQ 1d 2018-01-01 → 2024-12-31")
+    df = fetch_yfinance("QQQ", "2018-01-01", "2024-12-31", "1d")
+    _save(df, "qqq_1d_2018_2024.parquet")
+
+    # ── Fixture 3: Synthetic ETH-1h-style data (see configs.py for why) ───────
+    print("3. ETH-1h synthetic (seed=7, vol=0.025, drift=0.0002)")
+    df = generate_sample_data(
+        days=2000,
+        volatility=0.025,  # ~2.5% daily vol ≈ crypto-like
+        drift=0.0002,      # slight positive drift (avoids permanent open positions)
+        seed=7,
+        start_date="2018-01-01",
+    )
+    _save(df, "eth_1h_synthetic.parquet")
+
+    # ── Fixture 4: AAPL daily 2015-2024 ───────────────────────────────────────
+    print("4. AAPL 1d 2015-01-01 → 2024-12-31")
+    df = fetch_yfinance("AAPL", "2015-01-01", "2024-12-31", "1d")
+    _save(df, "aapl_1d_2015_2024.parquet")
+
+    # ── Fixture 5: TSLA daily 2020-2024 ───────────────────────────────────────
+    print("5. TSLA 1d 2020-01-01 → 2024-12-31")
+    df = fetch_yfinance("TSLA", "2020-01-01", "2024-12-31", "1d")
+    _save(df, "tsla_1d_2020_2024.parquet")
+
+    print("\nAll fixtures generated.")
+
+
+if __name__ == "__main__":
+    generate_all()

--- a/tests/regression/generate_hashes.py
+++ b/tests/regression/generate_hashes.py
@@ -1,0 +1,76 @@
+"""
+Compute and commit expected trade-log hashes for the regression harness.
+
+Run once after generating fixtures to produce expected_hashes.json:
+    python -m tests.regression.generate_hashes
+
+Re-run only when a phase intentionally changes backtest behavior
+(which should never happen — every phase must be behavior-preserving).
+"""
+import sys
+import json
+import hashlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+from src.strategy import StrategyParams
+from src.backtest import BacktestEngine
+from tests.regression.configs import CONFIGS
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+EXPECTED_PATH = Path(__file__).parent / "expected_hashes.json"
+
+
+def compute_trade_hash(trades) -> str:
+    if not trades:
+        return hashlib.sha256(b"").hexdigest()
+    rows = []
+    for t in trades:
+        rows.append({
+            "entry_time":  t.entry_date,
+            "exit_time":   t.exit_date,
+            "direction":   t.direction,
+            "entry_price": t.entry_price,
+            "exit_price":  t.exit_price,
+            "size":        t.size_dollars,
+            "pnl":         t.pnl,
+            "exit_reason": t.exit_reason,
+        })
+    trades_df = pd.DataFrame(rows)[
+        ["entry_time", "exit_time", "direction", "entry_price",
+         "exit_price", "size", "pnl", "exit_reason"]
+    ]
+    return hashlib.sha256(
+        pd.util.hash_pandas_object(trades_df, index=False).values.tobytes()
+    ).hexdigest()
+
+
+def generate_hashes() -> None:
+    hashes = {}
+    print("Computing trade-log hashes...\n")
+
+    for config_name, config_dict, fixture_file in CONFIGS:
+        fixture_path = FIXTURE_DIR / fixture_file
+        if not fixture_path.exists():
+            print(f"  MISSING fixture: {fixture_file}  — run generate_fixtures.py first")
+            sys.exit(1)
+
+        df = pd.read_parquet(fixture_path)
+        params = StrategyParams.from_dict(config_dict)
+        engine = BacktestEngine(params)
+        results = engine.run(df)
+        n = len(results.trades)
+        h = compute_trade_hash(results.trades)
+        hashes[config_name] = h
+        status = "OK" if n >= 5 else f"WARN: only {n} trades — hash may be fragile"
+        print(f"  {config_name}: {n} trades  [{status}]")
+        print(f"    hash: {h}")
+
+    EXPECTED_PATH.write_text(json.dumps(hashes, indent=2))
+    print(f"\nWrote {EXPECTED_PATH}")
+
+
+if __name__ == "__main__":
+    generate_hashes()

--- a/tests/regression/test_trade_log_hashes.py
+++ b/tests/regression/test_trade_log_hashes.py
@@ -1,0 +1,94 @@
+"""
+Regression harness: pins backtest behavior via trade-log SHA-256 hashes.
+
+Any phase of the indicator-registry refactor that changes these hashes
+has introduced a behavioral regression and must not be merged.
+
+Expected hashes live in expected_hashes.json (committed).
+Fixtures are committed parquet files under fixtures/.
+
+To regenerate (only when a phase intentionally changes behavior):
+    python -m tests.regression.generate_fixtures   # if fixtures need refresh
+    python -m tests.regression.generate_hashes     # recompute hashes
+"""
+import hashlib
+import json
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from src.strategy import StrategyParams
+from src.backtest import BacktestEngine
+from tests.regression.configs import CONFIGS
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+EXPECTED_HASHES_PATH = Path(__file__).parent / "expected_hashes.json"
+
+
+def _compute_trade_hash(trades) -> str:
+    if not trades:
+        return hashlib.sha256(b"").hexdigest()
+    rows = []
+    for t in trades:
+        rows.append({
+            "entry_time":  t.entry_date,
+            "exit_time":   t.exit_date,
+            "direction":   t.direction,
+            "entry_price": t.entry_price,
+            "exit_price":  t.exit_price,
+            "size":        t.size_dollars,
+            "pnl":         t.pnl,
+            "exit_reason": t.exit_reason,
+        })
+    trades_df = pd.DataFrame(rows)[
+        ["entry_time", "exit_time", "direction", "entry_price",
+         "exit_price", "size", "pnl", "exit_reason"]
+    ]
+    return hashlib.sha256(
+        pd.util.hash_pandas_object(trades_df, index=False).values.tobytes()
+    ).hexdigest()
+
+
+@pytest.fixture(scope="session")
+def expected_hashes() -> dict:
+    assert EXPECTED_HASHES_PATH.exists(), (
+        f"expected_hashes.json not found at {EXPECTED_HASHES_PATH}.\n"
+        "Run: python -m tests.regression.generate_hashes"
+    )
+    return json.loads(EXPECTED_HASHES_PATH.read_text())
+
+
+@pytest.mark.parametrize(
+    "config_name,config_dict,fixture_file",
+    CONFIGS,
+    ids=[c[0] for c in CONFIGS],
+)
+def test_trade_log_hash(config_name, config_dict, fixture_file, expected_hashes):
+    fixture_path = FIXTURE_DIR / fixture_file
+    assert fixture_path.exists(), (
+        f"Fixture missing: {fixture_path}\n"
+        "Run: python -m tests.regression.generate_fixtures"
+    )
+
+    df = pd.read_parquet(fixture_path)
+    params = StrategyParams.from_dict(config_dict)
+    engine = BacktestEngine(params)
+    results = engine.run(df)
+
+    n = len(results.trades)
+    assert n >= 5, (
+        f"{config_name}: only {n} trades — hash is meaningless. "
+        "Config may be too restrictive or fixture too short."
+    )
+
+    actual_hash = _compute_trade_hash(results.trades)
+    expected_hash = expected_hashes[config_name]
+
+    assert actual_hash == expected_hash, (
+        f"{config_name}: trade log changed!\n"
+        f"  expected: {expected_hash}\n"
+        f"  actual:   {actual_hash}\n"
+        f"  trades:   {n}\n"
+        "If this phase intentionally changes behavior, re-run generate_hashes.py "
+        "and justify the change in the PR description."
+    )

--- a/tests/test_optimizer_registry.py
+++ b/tests/test_optimizer_registry.py
@@ -1,0 +1,212 @@
+"""
+Optimizer registry integration tests (Phase 5).
+
+Verifies that:
+1. _count_active_params derives its count from the registry correctly
+2. _build_params_from_trial produces StrategyParams with all registry keys
+3. Seed reproducibility: same seed → same trial param sequence
+4. _is_entry_param uses registry membership, not prefix matching
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+import optuna
+from optuna.samplers import TPESampler
+
+optuna.logging.set_verbosity(optuna.logging.ERROR)
+
+from src.strategy import StrategyParams, TradeDirection
+from src.indicators.registry import INDICATOR_REGISTRY, build_defaults_from_registry
+from src.optimize import _count_active_params, _count_enabled_indicators, _is_entry_param
+from src.optimize import BayesianOptimizer
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def minimal_df():
+    """500-bar synthetic OHLCV DataFrame — enough for a small backtest."""
+    np.random.seed(0)
+    n = 500
+    close = 100 * np.exp(np.cumsum(np.random.normal(0.0002, 0.015, n)))
+    idx = pd.date_range("2020-01-01", periods=n, freq="D")
+    return pd.DataFrame({
+        "open":   close * 0.999,
+        "high":   close * 1.01,
+        "low":    close * 0.99,
+        "close":  close,
+        "volume": np.random.randint(1000, 5000, n).astype(float),
+    }, index=idx)
+
+
+@pytest.fixture(scope="module")
+def pamrp_only_filters():
+    return {
+        "pamrp_enabled": True,
+        "bbwp_enabled": False,
+        "adx_enabled": False,
+        "ma_trend_enabled": False,
+        "rsi_enabled": False,
+        "volume_enabled": False,
+        "supertrend_enabled": False,
+        "vwap_enabled": False,
+        "macd_enabled": False,
+        "stop_loss_enabled": False,
+        "take_profit_enabled": False,
+        "trailing_stop_enabled": False,
+        "atr_trailing_enabled": False,
+        "pamrp_exit_enabled": True,
+        "stoch_rsi_exit_enabled": False,
+        "time_exit_enabled": False,
+        "ma_exit_enabled": False,
+        "bbwp_exit_enabled": False,
+    }
+
+
+# ─── _count_active_params ─────────────────────────────────────────────────────
+
+def test_count_active_params_matches_registry_walk(pamrp_only_filters):
+    """_count_active_params result must equal a manual registry walk."""
+    # Manual count: enabled specs, optimize=True params, direction=both
+    expected = sum(
+        1
+        for spec in INDICATOR_REGISTRY
+        if pamrp_only_filters.get(spec.enable_param, False)
+        for p in spec.params
+        if p.optimize
+    )
+    result = _count_active_params(pamrp_only_filters, trade_direction=TradeDirection.BOTH)
+    assert result == max(expected, 1)
+
+
+def test_count_active_params_direction_long_only_skips_short_params(pamrp_only_filters):
+    both_count = _count_active_params(pamrp_only_filters, trade_direction=TradeDirection.BOTH)
+    long_count  = _count_active_params(pamrp_only_filters, trade_direction=TradeDirection.LONG_ONLY)
+    # LONG_ONLY skips direction="short" params — count must be ≤ BOTH count
+    assert long_count <= both_count
+
+
+def test_count_active_params_pinned_reduces_count(pamrp_only_filters):
+    base = _count_active_params(pamrp_only_filters)
+    pinned = {"pamrp_entry_ma_length": 20, "pamrp_entry_lookback": 350}
+    reduced = _count_active_params(pamrp_only_filters, pinned_params=pinned)
+    assert reduced == max(base - len(pinned), 1)
+
+
+# ─── _count_enabled_indicators ────────────────────────────────────────────────
+
+def test_count_enabled_indicators_only_counts_entry_group(pamrp_only_filters):
+    count = _count_enabled_indicators(pamrp_only_filters)
+    # Only pamrp_enabled=True in entry group
+    assert count == 1
+
+
+def test_count_enabled_indicators_all_off():
+    filters = {spec.enable_param: False for spec in INDICATOR_REGISTRY}
+    assert _count_enabled_indicators(filters) == 0
+
+
+# ─── _is_entry_param ──────────────────────────────────────────────────────────
+
+def test_is_entry_param_true_for_entry_group_params():
+    # Every param owned by an entry-group spec must be classified as entry
+    for spec in INDICATOR_REGISTRY:
+        if spec.group != "entry":
+            continue
+        for p in spec.params:
+            assert _is_entry_param(p.name), (
+                f"{p.name} (from entry spec {spec.key!r}) not classified as entry"
+            )
+
+
+def test_is_entry_param_false_for_exit_risk_params():
+    for spec in INDICATOR_REGISTRY:
+        if spec.group not in ("exit", "risk"):
+            continue
+        for p in spec.params:
+            assert not _is_entry_param(p.name), (
+                f"{p.name} (from {spec.group} spec {spec.key!r}) falsely classified as entry"
+            )
+
+
+# ─── _build_params_from_trial ─────────────────────────────────────────────────
+
+def test_build_params_from_trial_covers_all_registry_keys(minimal_df, pamrp_only_filters):
+    """Every registry param must appear in the StrategyParams produced by a trial."""
+    opt = BayesianOptimizer(
+        df=minimal_df,
+        enabled_filters=pamrp_only_filters,
+        trade_direction="long_only",
+    )
+    study = optuna.create_study(sampler=TPESampler(seed=0))
+    study.optimize(lambda t: (opt._build_params_from_trial(t), 0.0)[1], n_trials=1)
+    trial = study.trials[0]
+    params = opt._build_params_from_trial(
+        optuna.trial.FixedTrial(trial.params)
+    )
+    d = params.to_dict()
+    registry_keys = set(build_defaults_from_registry().keys())
+    missing = registry_keys - set(d.keys())
+    assert not missing, f"Missing registry keys in trial params: {missing}"
+
+
+def test_build_params_from_trial_disabled_uses_defaults(minimal_df, pamrp_only_filters):
+    """Params for disabled specs must equal registry defaults."""
+    opt = BayesianOptimizer(
+        df=minimal_df,
+        enabled_filters=pamrp_only_filters,
+        trade_direction="long_only",
+    )
+    study = optuna.create_study(sampler=TPESampler(seed=0))
+    study.optimize(lambda t: (opt._build_params_from_trial(t), 0.0)[1], n_trials=1)
+    trial = study.trials[0]
+    params = opt._build_params_from_trial(optuna.trial.FixedTrial(trial.params))
+    defaults = build_defaults_from_registry()
+
+    # RSI is disabled — its params must equal registry defaults
+    for spec in INDICATOR_REGISTRY:
+        if spec.key != "rsi":
+            continue
+        for p in spec.params:
+            assert params.to_dict()[p.name] == defaults[p.name], (
+                f"Disabled rsi param {p.name!r}: expected {defaults[p.name]!r}, "
+                f"got {params.to_dict()[p.name]!r}"
+            )
+
+
+# ─── Seed reproducibility ─────────────────────────────────────────────────────
+
+def test_optimizer_seed_reproducibility(minimal_df, pamrp_only_filters):
+    """
+    Two optimizer runs with the same TPE seed must produce identical trial
+    param sequences, confirming registry iteration is deterministically ordered.
+    """
+    def collect_trial_params(seed):
+        opt = BayesianOptimizer(
+            df=minimal_df,
+            enabled_filters=pamrp_only_filters,
+            trade_direction="both",
+        )
+        study = optuna.create_study(sampler=TPESampler(seed=seed))
+        study.optimize(lambda t: (opt._build_params_from_trial(t), 0.0)[1], n_trials=5)
+        return [t.params for t in study.trials]
+
+    run1 = collect_trial_params(42)
+    run2 = collect_trial_params(42)
+    assert run1 == run2, "Same seed produced different trial sequences — non-deterministic registry order"
+
+
+def test_different_seeds_produce_different_trials(minimal_df, pamrp_only_filters):
+    """Sanity check: different seeds should (very likely) yield different trials."""
+    def first_trial_params(seed):
+        opt = BayesianOptimizer(
+            df=minimal_df,
+            enabled_filters=pamrp_only_filters,
+            trade_direction="long_only",
+        )
+        study = optuna.create_study(sampler=TPESampler(seed=seed))
+        study.optimize(lambda t: (opt._build_params_from_trial(t), 0.0)[1], n_trials=1)
+        return study.trials[0].params
+
+    assert first_trial_params(0) != first_trial_params(99)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,5 @@
 """
-Registry schema and population tests (Phase 1 & 2).
+Registry schema and population tests (Phase 1, 2 & 3).
 
 These tests verify that:
 1. Every legacy StrategyParams field appears in the registry (or is a known strategy-level param)
@@ -8,11 +8,12 @@ These tests verify that:
 4. validate_registry() passes
 5. All compute/signal callables are named functions (not lambdas)
 6. calculate_indicators produces the expected column set (Phase 2)
+7. StrategyParams dict-backed shim behaves correctly (Phase 3)
 """
 import numpy as np
 import pandas as pd
 import pytest
-from src.strategy import StrategyParams, SignalGenerator
+from src.strategy import StrategyParams, SignalGenerator, TradeDirection
 from src.indicators.registry import (
     INDICATOR_REGISTRY,
     STRATEGY_LEVEL_PARAMS,
@@ -89,9 +90,9 @@ def test_categorical_params_have_choices():
 # ─── Coverage tests ───────────────────────────────────────────────────────────
 
 def test_all_legacy_params_present_in_registry():
-    """Every StrategyParams field is either in the registry or a known strategy-level param."""
-    legacy_fields = set(StrategyParams.__dataclass_fields__.keys())
-    indicator_fields = legacy_fields - STRATEGY_LEVEL_PARAMS
+    """Every indicator param in StrategyParams defaults is covered by the registry."""
+    sp_defaults = set(StrategyParams().to_dict().keys())
+    indicator_fields = sp_defaults - STRATEGY_LEVEL_PARAMS
     registry_params = set(build_defaults_from_registry().keys())
     missing = indicator_fields - registry_params
     assert not missing, (
@@ -100,24 +101,20 @@ def test_all_legacy_params_present_in_registry():
     )
 
 
-def test_registry_defaults_match_dataclass_defaults():
-    """Registry default for each param must equal the StrategyParams dataclass default."""
-    defaults_dc = {
-        k: v.default
-        for k, v in StrategyParams.__dataclass_fields__.items()
-        if k not in STRATEGY_LEVEL_PARAMS
-    }
+def test_registry_defaults_match_strategyparams_defaults():
+    """Registry default for each param must equal the StrategyParams default."""
+    sp = StrategyParams()
+    defaults_sp = {k: v for k, v in sp.to_dict().items() if k not in STRATEGY_LEVEL_PARAMS}
     defaults_reg = build_defaults_from_registry()
 
     mismatches = {}
-    for name, dc_default in defaults_dc.items():
-        if name in defaults_reg:
-            if defaults_reg[name] != dc_default:
-                mismatches[name] = (dc_default, defaults_reg[name])
+    for name, sp_default in defaults_sp.items():
+        if name in defaults_reg and defaults_reg[name] != sp_default:
+            mismatches[name] = (sp_default, defaults_reg[name])
 
     assert not mismatches, (
         "Registry defaults differ from StrategyParams defaults:\n"
-        + "\n".join(f"  {k}: dataclass={v[0]!r}, registry={v[1]!r}" for k, v in mismatches.items())
+        + "\n".join(f"  {k}: sp={v[0]!r}, registry={v[1]!r}" for k, v in mismatches.items())
     )
 
 
@@ -248,3 +245,88 @@ def test_calculate_indicators_does_not_mutate_input(sample_df):
     p = StrategyParams(pamrp_enabled=True, bbwp_enabled=True)
     SignalGenerator(p).calculate_indicators(sample_df)
     assert set(sample_df.columns) == original_cols
+
+
+# ─── Phase 3: StrategyParams dict-shim tests ──────────────────────────────────
+
+def test_strategyparams_attribute_access_matches_dict():
+    """Every key in to_dict() is reachable as an attribute (non-enum params match directly)."""
+    from enum import Enum
+    p = StrategyParams()
+    d = p.to_dict()
+    for key, val in d.items():
+        attr = getattr(p, key)
+        # Enum attrs store the enum object; to_dict serializes them to .value
+        normalized = attr.value if isinstance(attr, Enum) else attr
+        assert normalized == val, f"Attribute {key!r} mismatch: {normalized!r} != {val!r}"
+
+
+def test_strategyparams_unknown_attr_raises():
+    """Accessing an unknown attribute must raise AttributeError."""
+    p = StrategyParams()
+    with pytest.raises(AttributeError):
+        _ = p.bogus_attr_xyz
+
+
+def test_strategyparams_setattr_writes_through():
+    """Setting an attribute must update to_dict()."""
+    p = StrategyParams()
+    p.rsi_length = 21
+    assert p.to_dict()["rsi_length"] == 21
+    assert p.rsi_length == 21
+
+
+def test_strategyparams_overrides_applied():
+    """Constructor keyword args override registry defaults."""
+    p = StrategyParams(rsi_length=99, bbwp_enabled=False)
+    assert p.rsi_length == 99
+    assert p.bbwp_enabled is False
+
+
+def test_strategyparams_legacy_pamrp_length_migration():
+    """from_dict: pamrp_length (layer 1) → pamrp_entry_ma_length / pamrp_exit_ma_length."""
+    p = StrategyParams.from_dict({"pamrp_length": 30})
+    assert p.pamrp_entry_ma_length == 30
+    assert p.pamrp_exit_ma_length == 30
+
+
+def test_strategyparams_legacy_pamrp_entry_length_migration():
+    """from_dict: pamrp_entry_length (layer 2) → pamrp_entry_ma_length."""
+    p = StrategyParams.from_dict({"pamrp_entry_length": 42})
+    assert p.pamrp_entry_ma_length == 42
+
+
+def test_strategyparams_from_dict_direction_ui_strings():
+    """from_dict: UI display strings ('Long Only', 'Short Only', 'Both') are coerced."""
+    assert StrategyParams.from_dict({"trade_direction": "Long Only"}).trade_direction == TradeDirection.LONG_ONLY
+    assert StrategyParams.from_dict({"trade_direction": "Short Only"}).trade_direction == TradeDirection.SHORT_ONLY
+    assert StrategyParams.from_dict({"trade_direction": "Both"}).trade_direction == TradeDirection.BOTH
+
+
+def test_strategyparams_from_dict_direction_storage_strings():
+    """from_dict: storage-format strings ('long_only' etc.) are also coerced."""
+    assert StrategyParams.from_dict({"trade_direction": "long_only"}).trade_direction == TradeDirection.LONG_ONLY
+    assert StrategyParams.from_dict({"trade_direction": "both"}).trade_direction == TradeDirection.BOTH
+
+
+def test_strategyparams_from_dict_unknown_keys_ignored():
+    """from_dict: unrecognised keys are silently dropped."""
+    p = StrategyParams.from_dict({"rsi_length": 10, "totally_unknown_key": 999})
+    assert p.rsi_length == 10
+    with pytest.raises(AttributeError):
+        _ = p.totally_unknown_key
+
+
+def test_strategyparams_to_dict_serializes_enums():
+    """to_dict must return plain strings for enum values."""
+    p = StrategyParams(trade_direction=TradeDirection.SHORT_ONLY)
+    d = p.to_dict()
+    assert isinstance(d["trade_direction"], str)
+    assert d["trade_direction"] == "short_only"
+
+
+def test_strategyparams_time_exit_bars_migration():
+    """from_dict: time_exit_bars (legacy UI key) fans out to long/short split."""
+    p = StrategyParams.from_dict({"time_exit_bars": 15})
+    assert p.time_exit_bars_long == 15
+    assert p.time_exit_bars_short == 15

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,181 @@
+"""
+Registry schema and population tests (Phase 1).
+
+These tests verify that:
+1. Every legacy StrategyParams field appears in the registry (or is a known strategy-level param)
+2. Registry defaults match dataclass defaults exactly
+3. No duplicate param names or indicator keys
+4. validate_registry() passes
+5. All compute/signal callables are named functions (not lambdas)
+"""
+import pytest
+from src.strategy import StrategyParams
+from src.indicators.registry import (
+    INDICATOR_REGISTRY,
+    STRATEGY_LEVEL_PARAMS,
+    all_specs,
+    build_defaults_from_registry,
+    enabled_specs,
+    topological_sort,
+    validate_registry,
+)
+# Importing specs triggers registration and validate_registry()
+import src.indicators.specs  # noqa: F401
+
+
+# ─── Schema tests ─────────────────────────────────────────────────────────────
+
+def test_validate_registry_passes():
+    """validate_registry() should not raise."""
+    validate_registry()
+
+
+def test_no_duplicate_indicator_keys():
+    keys = [s.key for s in INDICATOR_REGISTRY]
+    assert len(keys) == len(set(keys)), f"Duplicate indicator keys: {keys}"
+
+
+def test_no_duplicate_param_names():
+    names = []
+    for spec in INDICATOR_REGISTRY:
+        for p in spec.params:
+            names.append(p.name)
+    assert len(names) == len(set(names)), (
+        f"Duplicate param names: {[n for n in names if names.count(n) > 1]}"
+    )
+
+
+def test_compute_callables_are_named_not_lambda():
+    for spec in all_specs():
+        for attr, fn in [
+            ("compute", spec.compute),
+            ("long_signal", spec.long_signal),
+            ("short_signal", spec.short_signal),
+        ]:
+            if fn is not None:
+                assert not fn.__name__.startswith("<lambda>"), (
+                    f"{spec.key}.{attr} is a lambda — use a named function"
+                )
+
+
+def test_all_enable_params_are_bool():
+    for spec in all_specs():
+        ep = next((p for p in spec.params if p.name == spec.enable_param), None)
+        assert ep is not None, f"{spec.key}: enable_param '{spec.enable_param}' not in params"
+        assert ep.type == "bool", f"{spec.key}: enable_param must be type='bool'"
+
+
+def test_numeric_params_have_min_max():
+    for spec in all_specs():
+        for p in spec.params:
+            if p.type in ("int", "float"):
+                assert p.min is not None and p.max is not None, (
+                    f"{spec.key}.{p.name}: numeric param missing min or max"
+                )
+
+
+def test_categorical_params_have_choices():
+    for spec in all_specs():
+        for p in spec.params:
+            if p.type == "categorical":
+                assert p.choices, (
+                    f"{spec.key}.{p.name}: categorical param missing choices"
+                )
+
+
+# ─── Coverage tests ───────────────────────────────────────────────────────────
+
+def test_all_legacy_params_present_in_registry():
+    """Every StrategyParams field is either in the registry or a known strategy-level param."""
+    legacy_fields = set(StrategyParams.__dataclass_fields__.keys())
+    indicator_fields = legacy_fields - STRATEGY_LEVEL_PARAMS
+    registry_params = set(build_defaults_from_registry().keys())
+    missing = indicator_fields - registry_params
+    assert not missing, (
+        f"StrategyParams fields not found in registry: {sorted(missing)}\n"
+        "Add a ParamSpec for each, or add to STRATEGY_LEVEL_PARAMS if they're not indicators."
+    )
+
+
+def test_registry_defaults_match_dataclass_defaults():
+    """Registry default for each param must equal the StrategyParams dataclass default."""
+    defaults_dc = {
+        k: v.default
+        for k, v in StrategyParams.__dataclass_fields__.items()
+        if k not in STRATEGY_LEVEL_PARAMS
+    }
+    defaults_reg = build_defaults_from_registry()
+
+    mismatches = {}
+    for name, dc_default in defaults_dc.items():
+        if name in defaults_reg:
+            if defaults_reg[name] != dc_default:
+                mismatches[name] = (dc_default, defaults_reg[name])
+
+    assert not mismatches, (
+        "Registry defaults differ from StrategyParams defaults:\n"
+        + "\n".join(f"  {k}: dataclass={v[0]!r}, registry={v[1]!r}" for k, v in mismatches.items())
+    )
+
+
+# ─── Functional tests ─────────────────────────────────────────────────────────
+
+def test_build_defaults_from_registry_returns_all_indicator_params():
+    defaults = build_defaults_from_registry()
+    # Spot-check a few known params
+    assert "pamrp_enabled" in defaults
+    assert defaults["pamrp_enabled"] is True
+    assert "rsi_length" in defaults
+    assert defaults["rsi_length"] == 14
+    assert "stop_loss_pct_long" in defaults
+    assert defaults["stop_loss_pct_long"] == 3.0
+
+
+def test_enabled_specs_filters_by_enable_param():
+    defaults = build_defaults_from_registry()
+    specs = enabled_specs(defaults)
+    enabled_keys = {s.key for s in specs}
+
+    # These are enabled by default
+    assert "pamrp_entry" in enabled_keys
+    assert "pamrp_exit" in enabled_keys
+    assert "bbwp_entry" in enabled_keys
+    assert "stop_loss" in enabled_keys
+
+    # These are disabled by default
+    assert "rsi" not in enabled_keys
+    assert "macd" not in enabled_keys
+    assert "supertrend" not in enabled_keys
+
+
+def test_topological_sort_puts_deps_first():
+    specs = all_specs()
+    sorted_specs = topological_sort(specs)
+    key_order = {s.key: i for i, s in enumerate(sorted_specs)}
+
+    for spec in sorted_specs:
+        for dep_key in spec.reuses_outputs_from:
+            if dep_key in key_order:
+                assert key_order[dep_key] < key_order[spec.key], (
+                    f"Dependency '{dep_key}' must come before '{spec.key}' in sorted order"
+                )
+
+
+def test_bbwp_exit_comes_after_bbwp_entry_in_sort():
+    sorted_specs = topological_sort(all_specs())
+    key_order = {s.key: i for i, s in enumerate(sorted_specs)}
+    assert key_order["bbwp_entry"] < key_order["bbwp_exit"]
+
+
+def test_pamrp_exit_comes_after_pamrp_entry_in_sort():
+    sorted_specs = topological_sort(all_specs())
+    key_order = {s.key: i for i, s in enumerate(sorted_specs)}
+    assert key_order["pamrp_entry"] < key_order["pamrp_exit"]
+
+
+def test_registry_covers_18_indicators():
+    """Exact indicator count check — update when adding new indicators."""
+    assert len(INDICATOR_REGISTRY) == 18, (
+        f"Expected 18 indicators, got {len(INDICATOR_REGISTRY)}. "
+        "Update this count if adding a new indicator."
+    )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,5 @@
 """
-Registry schema and population tests (Phase 1).
+Registry schema and population tests (Phase 1 & 2).
 
 These tests verify that:
 1. Every legacy StrategyParams field appears in the registry (or is a known strategy-level param)
@@ -7,9 +7,12 @@ These tests verify that:
 3. No duplicate param names or indicator keys
 4. validate_registry() passes
 5. All compute/signal callables are named functions (not lambdas)
+6. calculate_indicators produces the expected column set (Phase 2)
 """
+import numpy as np
+import pandas as pd
 import pytest
-from src.strategy import StrategyParams
+from src.strategy import StrategyParams, SignalGenerator
 from src.indicators.registry import (
     INDICATOR_REGISTRY,
     STRATEGY_LEVEL_PARAMS,
@@ -179,3 +182,69 @@ def test_registry_covers_18_indicators():
         f"Expected 18 indicators, got {len(INDICATOR_REGISTRY)}. "
         "Update this count if adding a new indicator."
     )
+
+
+# ─── Phase 2: calculate_indicators column-set tests ───────────────────────────
+
+@pytest.fixture(scope="module")
+def sample_df():
+    np.random.seed(42)
+    n = 300
+    close = 100 * np.exp(np.cumsum(np.random.normal(0, 0.01, n)))
+    idx = pd.date_range("2020-01-01", periods=n, freq="D")
+    return pd.DataFrame({
+        "open": close * 0.999, "high": close * 1.005,
+        "low": close * 0.995, "close": close,
+        "volume": np.random.randint(1000, 5000, n).astype(float),
+    }, index=idx)
+
+
+def test_calculate_indicators_all_disabled_has_fallback_columns(sample_df):
+    """When all indicators disabled, legacy fallback columns are still present."""
+    p = StrategyParams(
+        pamrp_enabled=False, pamrp_exit_enabled=False,
+        bbwp_enabled=False, bbwp_exit_enabled=False,
+    )
+    result = SignalGenerator(p).calculate_indicators(sample_df)
+    for col in ("pamrp_entry", "pamrp_exit", "pamrp", "bbwp", "bbwp_sma"):
+        assert col in result.columns, f"Missing fallback column: {col}"
+    assert (result["pamrp_entry"] == 50.0).all()
+    assert (result["bbwp"] == 50.0).all()
+
+
+def test_calculate_indicators_all_enabled_has_expected_columns(sample_df):
+    """When all indicators enabled, all output columns are present."""
+    p = StrategyParams(
+        pamrp_enabled=True, pamrp_exit_enabled=True,
+        bbwp_enabled=True, bbwp_exit_enabled=True,
+        adx_enabled=True, ma_trend_enabled=True,
+        rsi_enabled=True, stoch_rsi_exit_enabled=True,
+        volume_enabled=True, supertrend_enabled=True,
+        vwap_enabled=True, macd_enabled=True,
+        atr_trailing_enabled=True, ma_exit_enabled=True,
+    )
+    result = SignalGenerator(p).calculate_indicators(sample_df)
+    expected = {
+        "pamrp_entry", "pamrp_exit", "pamrp",
+        "bbwp", "bbwp_sma",
+        "adx", "di_plus", "di_minus",
+        "ma_fast", "ma_slow",
+        "rsi",
+        "stoch_k", "stoch_d",
+        "volume_ma",
+        "supertrend", "st_direction",
+        "vwap",
+        "macd", "macd_signal", "macd_hist",
+        "atr",
+        "exit_ma_fast", "exit_ma_slow",
+    }
+    missing = expected - set(result.columns)
+    assert not missing, f"Missing columns: {missing}"
+
+
+def test_calculate_indicators_does_not_mutate_input(sample_df):
+    """calculate_indicators must not modify the original DataFrame."""
+    original_cols = set(sample_df.columns)
+    p = StrategyParams(pamrp_enabled=True, bbwp_enabled=True)
+    SignalGenerator(p).calculate_indicators(sample_df)
+    assert set(sample_df.columns) == original_cols

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -203,6 +203,7 @@ class TestStrategy:
         }, index=idx)
         params = StrategyParams(
             pamrp_enabled=True,
+            bbwp_enabled=False,
             rsi_enabled=True,
             entry_operator=ConditionOperator.OR,
             trade_direction=TradeDirection.BOTH,
@@ -222,6 +223,7 @@ class TestStrategy:
         }, index=idx)
         params = StrategyParams(
             pamrp_enabled=True,
+            bbwp_enabled=False,
             rsi_enabled=True,
             entry_operator=ConditionOperator.AND,
             trade_direction=TradeDirection.BOTH,
@@ -248,7 +250,8 @@ class TestStrategy:
         result = SignalGenerator(params).generate_exit_signals(df)
 
         assert result['exit_long_signal'].tolist() == [True, True, True]
-        assert result['exit_short_signal'].tolist() == [False, False, False]
+        # bbwp=70 < threshold=80 → short exit fires on bar 0 (via OR)
+        assert result['exit_short_signal'].tolist() == [True, False, False]
 
     def test_exit_operator_and_requires_all_signal_exits(self):
         """AND exit mode should require every enabled signal exit condition to pass."""

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -59,87 +59,8 @@ PARAM_TO_WIDGET_KEY: Dict[str, str] = {
 # ─────────────────────────────────────────────────────────────────────────────
 
 def params_to_strategy(p: Dict[str, Any]) -> StrategyParams:
-    """Convert the flat session-state params dict into a typed StrategyParams object."""
-    p = migrate_legacy_pamrp_params(p)
-    direction_map = {
-        'Long Only': TradeDirection.LONG_ONLY,
-        'Short Only': TradeDirection.SHORT_ONLY,
-        'Both': TradeDirection.BOTH,
-    }
-
-    def parse_operator(value: Any, default: ConditionOperator) -> ConditionOperator:
-        if isinstance(value, ConditionOperator):
-            return value
-        if isinstance(value, str):
-            try:
-                return ConditionOperator(value.lower())
-            except ValueError:
-                return default
-        return default
-
-    def parse_entry_conflict_mode(value: Any, default: EntryConflictMode) -> EntryConflictMode:
-        if isinstance(value, EntryConflictMode):
-            return value
-        if isinstance(value, str):
-            try:
-                return EntryConflictMode(value.lower())
-            except ValueError:
-                return default
-        return default
-
-    return StrategyParams(
-        trade_direction=direction_map.get(p.get('trade_direction', 'Long Only'), TradeDirection.LONG_ONLY),
-        entry_operator=parse_operator(p.get('entry_operator', 'and'), ConditionOperator.AND),
-        exit_operator=parse_operator(p.get('exit_operator', 'or'), ConditionOperator.OR),
-        allow_same_bar_exit=p.get('allow_same_bar_exit', True),
-        allow_same_bar_reversal=p.get('allow_same_bar_reversal', False),
-        entry_conflict_mode=parse_entry_conflict_mode(p.get('entry_conflict_mode', 'skip'), EntryConflictMode.SKIP),
-        position_size_pct=p.get('position_size_pct', 100.0),
-        use_kelly=p.get('use_kelly', False), kelly_fraction=p.get('kelly_fraction', 0.5),
-        pamrp_enabled=p.get('pamrp_enabled', True),
-        pamrp_entry_ma_length=p.get('pamrp_entry_ma_length', 20),
-        pamrp_entry_lookback=p.get('pamrp_entry_lookback', 350),
-        pamrp_entry_ma_type=p.get('pamrp_entry_ma_type', 'sma'),
-        pamrp_entry_long=p.get('pamrp_entry_long', 20), pamrp_entry_short=p.get('pamrp_entry_short', 80),
-        pamrp_exit_ma_length=p.get('pamrp_exit_ma_length', 20),
-        pamrp_exit_lookback=p.get('pamrp_exit_lookback', 350),
-        pamrp_exit_ma_type=p.get('pamrp_exit_ma_type', 'sma'),
-        pamrp_exit_long=p.get('pamrp_exit_long', 70), pamrp_exit_short=p.get('pamrp_exit_short', 30),
-        bbwp_enabled=p.get('bbwp_enabled', True), bbwp_length=p.get('bbwp_length', 13),
-        bbwp_lookback=p.get('bbwp_lookback', 252), bbwp_sma_length=p.get('bbwp_sma_length', 5),
-        bbwp_threshold_long=p.get('bbwp_threshold_long', 50), bbwp_threshold_short=p.get('bbwp_threshold_short', 50),
-        bbwp_ma_filter=p.get('bbwp_ma_filter', 'disabled'),
-        adx_enabled=p.get('adx_enabled', False), adx_length=p.get('adx_length', 14),
-        adx_smoothing=p.get('adx_smoothing', 14), adx_threshold=p.get('adx_threshold', 20),
-        ma_trend_enabled=p.get('ma_trend_enabled', False), ma_fast_length=p.get('ma_fast_length', 50),
-        ma_slow_length=p.get('ma_slow_length', 200), ma_type=p.get('ma_type', 'sma'),
-        rsi_enabled=p.get('rsi_enabled', False), rsi_length=p.get('rsi_length', 14),
-        rsi_oversold=p.get('rsi_oversold', 30), rsi_overbought=p.get('rsi_overbought', 70),
-        volume_enabled=p.get('volume_enabled', False), volume_ma_length=p.get('volume_ma_length', 20),
-        volume_multiplier=p.get('volume_multiplier', 1.0),
-        supertrend_enabled=p.get('supertrend_enabled', False), supertrend_period=p.get('supertrend_period', 10),
-        supertrend_multiplier=p.get('supertrend_multiplier', 3.0),
-        vwap_enabled=p.get('vwap_enabled', False),
-        macd_enabled=p.get('macd_enabled', False), macd_fast=p.get('macd_fast', 12),
-        macd_slow=p.get('macd_slow', 26), macd_signal=p.get('macd_signal', 9),
-        stop_loss_enabled=p.get('stop_loss_enabled', True),
-        stop_loss_pct_long=p.get('stop_loss_pct_long', 3.0), stop_loss_pct_short=p.get('stop_loss_pct_short', 3.0),
-        take_profit_enabled=p.get('take_profit_enabled', False),
-        take_profit_pct_long=p.get('take_profit_pct_long', 5.0), take_profit_pct_short=p.get('take_profit_pct_short', 5.0),
-        trailing_stop_enabled=p.get('trailing_stop_enabled', False), trailing_stop_pct=p.get('trailing_stop_pct', 2.0),
-        atr_trailing_enabled=p.get('atr_trailing_enabled', False), atr_length=p.get('atr_length', 14),
-        atr_multiplier=p.get('atr_multiplier', 2.0),
-        pamrp_exit_enabled=p.get('pamrp_exit_enabled', True),
-        stoch_rsi_exit_enabled=p.get('stoch_rsi_exit_enabled', False),
-        stoch_rsi_length=p.get('stoch_rsi_length', 14), stoch_rsi_k=p.get('stoch_rsi_k', 3),
-        stoch_rsi_d=p.get('stoch_rsi_d', 3), stoch_rsi_overbought=p.get('stoch_rsi_overbought', 80),
-        stoch_rsi_oversold=p.get('stoch_rsi_oversold', 20),
-        time_exit_enabled=p.get('time_exit_enabled', False),
-        time_exit_bars_long=p.get('time_exit_bars', 20), time_exit_bars_short=p.get('time_exit_bars', 20),
-        ma_exit_enabled=p.get('ma_exit_enabled', False), ma_exit_fast=p.get('ma_exit_fast', 10),
-        ma_exit_slow=p.get('ma_exit_slow', 20),
-        bbwp_exit_enabled=p.get('bbwp_exit_enabled', False), bbwp_exit_threshold=p.get('bbwp_exit_threshold', 80),
-    )
+    """Convert the flat session-state params dict into a StrategyParams object."""
+    return StrategyParams.from_dict(p)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -6,7 +6,6 @@ Pure helper functions and constants shared across sidebar and tab modules.
   - params_to_strategy()        — Dict → StrategyParams
   - get_active_filters_display() — list of enabled indicator labels
   - calculate_beta_alpha()       — beta / alpha / correlation vs benchmark
-  - PARAM_TO_WIDGET_KEY          — sidebar widget-key lookup
   - apply_best_params_callback() — Streamlit on_click callback for "Apply Best Params"
 """
 

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -15,42 +15,17 @@ import streamlit as st
 from typing import Dict, Any
 
 from src.strategy import StrategyParams, TradeDirection, ConditionOperator, EntryConflictMode
+from src.indicators.registry import INDICATOR_REGISTRY
 from ui.state_migration import migrate_legacy_pamrp_params
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Widget-key mapping (param name → short Streamlit widget key)
-# ─────────────────────────────────────────────────────────────────────────────
-
-PARAM_TO_WIDGET_KEY: Dict[str, str] = {
-    'trade_direction': 'tdir',
-    'entry_operator': 'eop', 'exit_operator': 'xop',
-    'allow_same_bar_exit': 'same_bar_exit',
-    'allow_same_bar_reversal': 'same_bar_reversal',
-    'entry_conflict_mode': 'ecm',
-    'pamrp_enabled': 'pe',
-    'pamrp_entry_ma_length': 'ple_ma', 'pamrp_entry_lookback': 'ple_lb', 'pamrp_entry_ma_type': 'ple_mt',
-    'pamrp_entry_long': 'pel', 'pamrp_entry_short': 'pes',
-    'pamrp_exit_ma_length': 'pxl_ma', 'pamrp_exit_lookback': 'pxl_lb', 'pamrp_exit_ma_type': 'pxl_mt',
-    'pamrp_exit_long': 'pxl_exit', 'pamrp_exit_short': 'pxs_exit',
-    'bbwp_enabled': 'be', 'bbwp_length': 'bl', 'bbwp_lookback': 'blb', 'bbwp_sma_length': 'bsma',
-    'bbwp_threshold_long': 'btl', 'bbwp_threshold_short': 'bts', 'bbwp_ma_filter': 'bmf',
-    'adx_enabled': 'ae', 'adx_length': 'al', 'adx_threshold': 'at',
-    'ma_trend_enabled': 'mae', 'ma_type': 'mat', 'ma_fast_length': 'maf', 'ma_slow_length': 'mas',
-    'rsi_enabled': 're', 'rsi_length': 'rl', 'rsi_oversold': 'ros', 'rsi_overbought': 'rob',
-    'volume_enabled': 've', 'volume_ma_length': 'vml', 'volume_multiplier': 'vm',
-    'supertrend_enabled': 'ste', 'supertrend_period': 'stp', 'supertrend_multiplier': 'stm',
-    'vwap_enabled': 'vwe', 'macd_enabled': 'mce', 'macd_fast': 'mcf', 'macd_slow': 'mcs', 'macd_signal': 'mcsi',
-    'stop_loss_enabled': 'sle', 'stop_loss_pct_long': 'sll', 'stop_loss_pct_short': 'sls',
-    'take_profit_enabled': 'tpe', 'take_profit_pct_long': 'tpl', 'take_profit_pct_short': 'tps',
-    'trailing_stop_enabled': 'tse', 'trailing_stop_pct': 'tsp',
-    'atr_trailing_enabled': 'ate', 'atr_length': 'atl', 'atr_multiplier': 'atm',
-    'pamrp_exit_enabled': 'pxe',
-    'stoch_rsi_exit_enabled': 'sre', 'stoch_rsi_length': 'srl', 'stoch_rsi_k': 'srk', 'stoch_rsi_d': 'srd',
-    'stoch_rsi_overbought': 'srob', 'stoch_rsi_oversold': 'sros',
-    'time_exit_enabled': 'txe', 'time_exit_bars': 'txb',
-    'ma_exit_enabled': 'mxe', 'ma_exit_fast': 'mxf', 'ma_exit_slow': 'mxs',
-    'bbwp_exit_enabled': 'bxe', 'bbwp_exit_threshold': 'bxt',
+# Strategy-level params keep their hand-coded widget keys (not registry-driven).
+_STRATEGY_WIDGET_KEYS: Dict[str, str] = {
+    'entry_operator':         'eop',
+    'exit_operator':          'xop',
+    'allow_same_bar_exit':    'same_bar_exit',
+    'allow_same_bar_reversal':'same_bar_reversal',
+    'entry_conflict_mode':    'ecm',
 }
 
 
@@ -69,18 +44,11 @@ def params_to_strategy(p: Dict[str, Any]) -> StrategyParams:
 
 def get_active_filters_display(params: Dict[str, Any]):
     """Return a list of human-readable labels for every enabled indicator / exit."""
-    entry = {
-        'pamrp_enabled': 'PAMRP', 'bbwp_enabled': 'BBWP', 'adx_enabled': 'ADX',
-        'ma_trend_enabled': 'MA Trend', 'rsi_enabled': 'RSI', 'volume_enabled': 'Volume',
-        'supertrend_enabled': 'Supertrend', 'vwap_enabled': 'VWAP', 'macd_enabled': 'MACD',
-    }
-    exits = {
-        'stop_loss_enabled': 'Stop Loss', 'take_profit_enabled': 'Take Profit',
-        'trailing_stop_enabled': 'Trailing Stop', 'atr_trailing_enabled': 'ATR Trail',
-        'pamrp_exit_enabled': 'PAMRP Exit', 'stoch_rsi_exit_enabled': 'Stoch RSI Exit',
-        'time_exit_enabled': 'Time Exit', 'ma_exit_enabled': 'MA Exit', 'bbwp_exit_enabled': 'BBWP Exit',
-    }
-    return [l for k, l in {**entry, **exits}.items() if params.get(k, False)]
+    return [
+        spec.name
+        for spec in INDICATOR_REGISTRY
+        if params.get(spec.enable_param, False)
+    ]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -119,8 +87,9 @@ def apply_best_params_callback() -> None:
             continue
         if k in st.session_state.params:
             st.session_state.params[k] = v
-        wk = PARAM_TO_WIDGET_KEY.get(k)
-        if wk:
+        # Strategy-level params keep hand-coded widget keys; indicator params use widget_{name}
+        wk = _STRATEGY_WIDGET_KEYS.get(k, f"widget_{k}")
+        if wk in st.session_state:
             st.session_state[wk] = v
     if 'trade_direction_str' in bp:
         dm = {'long_only': 'Long Only', 'short_only': 'Short Only', 'both': 'Both'}

--- a/ui/session.py
+++ b/ui/session.py
@@ -45,7 +45,7 @@ def get_default_params() -> Dict[str, Any]:
         'pamrp_exit_enabled': False,
         'stoch_rsi_exit_enabled': False, 'stoch_rsi_length': 14, 'stoch_rsi_k': 3, 'stoch_rsi_d': 3,
         'stoch_rsi_overbought': 80, 'stoch_rsi_oversold': 20,
-        'time_exit_enabled': False, 'time_exit_bars': 20,
+        'time_exit_enabled': False, 'time_exit_bars_long': 20, 'time_exit_bars_short': 20,
         'ma_exit_enabled': False, 'ma_exit_fast': 10, 'ma_exit_slow': 20,
         'bbwp_exit_enabled': False, 'bbwp_exit_threshold': 80,
         # ── Visual indicators (display-only, not strategy filters) ────────────

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -12,6 +12,7 @@ import streamlit as st
 from datetime import datetime, timedelta
 
 from src.data import fetch_yfinance, generate_sample_data, load_csv
+from ui.sidebar_renderer import render_indicator_section
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -192,71 +193,7 @@ def _render_entry_indicators(p: dict) -> None:
         horizontal=True,
         key="eop",
     )
-
-    with st.expander("📊 PAMRP", expanded=False):
-        p['pamrp_enabled'] = st.toggle("Enable", p['pamrp_enabled'], key="pe")
-        if p['pamrp_enabled']:
-            p['pamrp_entry_ma_length'] = st.slider("MA Length", 5, 100, p['pamrp_entry_ma_length'], key="ple_ma")
-            p['pamrp_entry_lookback']  = st.slider("Lookback", 50, 500, p['pamrp_entry_lookback'], key="ple_lb")
-            p['pamrp_entry_ma_type']   = st.selectbox("MA Type", ["sma", "ema", "wma", "rma"],
-                index=["sma", "ema", "wma", "rma"].index(p['pamrp_entry_ma_type']), key="ple_mt")
-            p['pamrp_entry_long']  = st.slider("Entry Long", 5, 50, p['pamrp_entry_long'], key="pel")
-            p['pamrp_entry_short'] = st.slider("Entry Short", 50, 95, p['pamrp_entry_short'], key="pes")
-
-
-    with st.expander("📊 BBWP", expanded=False):
-        p['bbwp_enabled'] = st.toggle("Enable", p['bbwp_enabled'], key="be")
-        if p['bbwp_enabled']:
-            p['bbwp_length'] = st.slider("Length", 5, 30, p['bbwp_length'], key="bl")
-            p['bbwp_lookback'] = st.slider("Lookback", 50, 400, p['bbwp_lookback'], key="blb")
-            p['bbwp_sma_length'] = st.slider("SMA", 2, 15, p['bbwp_sma_length'], key="bsma")
-            p['bbwp_threshold_long'] = st.slider("Thresh Long", 20, 80, p['bbwp_threshold_long'], key="btl")
-            p['bbwp_threshold_short'] = st.slider("Thresh Short", 20, 80, p['bbwp_threshold_short'], key="bts")
-            p['bbwp_ma_filter'] = st.selectbox("MA Filter", ["disabled", "decreasing", "increasing"],
-                index=["disabled", "decreasing", "increasing"].index(p['bbwp_ma_filter']), key="bmf")
-
-    with st.expander("📈 ADX", expanded=False):
-        p['adx_enabled'] = st.toggle("Enable", p['adx_enabled'], key="ae")
-        if p['adx_enabled']:
-            p['adx_length'] = st.slider("Length", 7, 21, p['adx_length'], key="al")
-            p['adx_threshold'] = st.slider("Threshold", 10, 40, p['adx_threshold'], key="at")
-
-    with st.expander("📈 MA Trend", expanded=False):
-        p['ma_trend_enabled'] = st.toggle("Enable", p['ma_trend_enabled'], key="mae")
-        if p['ma_trend_enabled']:
-            p['ma_type'] = st.selectbox("Type", ["sma", "ema"],
-                index=["sma", "ema"].index(p['ma_type']), key="mat")
-            p['ma_fast_length'] = st.slider("Fast", 10, 100, p['ma_fast_length'], key="maf")
-            p['ma_slow_length'] = st.slider("Slow", 50, 400, p['ma_slow_length'], key="mas")
-
-    with st.expander("📈 RSI", expanded=False):
-        p['rsi_enabled'] = st.toggle("Enable", p['rsi_enabled'], key="re")
-        if p['rsi_enabled']:
-            p['rsi_length'] = st.slider("Length", 5, 21, p['rsi_length'], key="rl")
-            p['rsi_oversold'] = st.slider("Oversold", 15, 45, p['rsi_oversold'], key="ros")
-            p['rsi_overbought'] = st.slider("Overbought", 55, 85, p['rsi_overbought'], key="rob")
-
-    with st.expander("📊 Volume", expanded=False):
-        p['volume_enabled'] = st.toggle("Enable", p['volume_enabled'], key="ve")
-        if p['volume_enabled']:
-            p['volume_ma_length'] = st.slider("MA Length", 10, 50, p['volume_ma_length'], key="vml")
-            p['volume_multiplier'] = st.slider("Multiplier", 0.5, 2.0, p['volume_multiplier'], 0.1, key="vm")
-
-    with st.expander("📈 Supertrend", expanded=False):
-        p['supertrend_enabled'] = st.toggle("Enable", p['supertrend_enabled'], key="ste")
-        if p['supertrend_enabled']:
-            p['supertrend_period'] = st.slider("Period", 5, 20, p['supertrend_period'], key="stp")
-            p['supertrend_multiplier'] = st.slider("Mult", 1.0, 5.0, p['supertrend_multiplier'], 0.5, key="stm")
-
-    with st.expander("📈 VWAP", expanded=False):
-        p['vwap_enabled'] = st.toggle("Enable", p['vwap_enabled'], key="vwe")
-
-    with st.expander("📈 MACD", expanded=False):
-        p['macd_enabled'] = st.toggle("Enable", p['macd_enabled'], key="mce")
-        if p['macd_enabled']:
-            p['macd_fast'] = st.slider("Fast", 5, 20, p['macd_fast'], key="mcf")
-            p['macd_slow'] = st.slider("Slow", 15, 40, p['macd_slow'], key="mcs")
-            p['macd_signal'] = st.slider("Signal", 5, 15, p['macd_signal'], key="mcsi")
+    render_indicator_section("entry", p)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -318,60 +255,5 @@ def _render_exit_indicators(p: dict) -> None:
         help="Applies to signal-based exits below. Stop-loss, take-profit, trailing, ATR, and time exits still trigger independently.",
     )
 
-    with st.expander("🛑 Stop Loss", expanded=False):
-        p['stop_loss_enabled'] = st.toggle("Enable", p['stop_loss_enabled'], key="sle")
-        if p['stop_loss_enabled']:
-            p['stop_loss_pct_long'] = st.slider("% Long", 0.5, 15.0, p['stop_loss_pct_long'], 0.5, key="sll")
-            p['stop_loss_pct_short'] = st.slider("% Short", 0.5, 15.0, p['stop_loss_pct_short'], 0.5, key="sls")
-
-    with st.expander("🎯 Take Profit", expanded=False):
-        p['take_profit_enabled'] = st.toggle("Enable", p['take_profit_enabled'], key="tpe")
-        if p['take_profit_enabled']:
-            p['take_profit_pct_long'] = st.slider("% Long", 1.0, 30.0, p['take_profit_pct_long'], 0.5, key="tpl")
-            p['take_profit_pct_short'] = st.slider("% Short", 1.0, 30.0, p['take_profit_pct_short'], 0.5, key="tps")
-
-    with st.expander("📉 Trailing Stop", expanded=False):
-        p['trailing_stop_enabled'] = st.toggle("Enable", p['trailing_stop_enabled'], key="tse")
-        if p['trailing_stop_enabled']:
-            p['trailing_stop_pct'] = st.slider("Trail %", 0.5, 10.0, p['trailing_stop_pct'], 0.5, key="tsp")
-
-    with st.expander("📉 ATR Trail", expanded=False):
-        p['atr_trailing_enabled'] = st.toggle("Enable", p['atr_trailing_enabled'], key="ate")
-        if p['atr_trailing_enabled']:
-            p['atr_length'] = st.slider("Length", 7, 21, p['atr_length'], key="atl")
-            p['atr_multiplier'] = st.slider("Mult", 1.0, 5.0, p['atr_multiplier'], 0.5, key="atm")
-
-    with st.expander("📊 PAMRP Exit", expanded=False):
-        p['pamrp_exit_enabled'] = st.toggle("Enable", p['pamrp_exit_enabled'], key="pxe")
-        if p['pamrp_exit_enabled']:
-            p['pamrp_exit_ma_length'] = st.slider("MA Length", 5, 100, p['pamrp_exit_ma_length'], key="pxl_ma")
-            p['pamrp_exit_lookback']  = st.slider("Lookback", 50, 500, p['pamrp_exit_lookback'], key="pxl_lb")
-            p['pamrp_exit_ma_type']   = st.selectbox("MA Type", ["sma", "ema", "wma", "rma"],
-                index=["sma", "ema", "wma", "rma"].index(p['pamrp_exit_ma_type']), key="pxl_mt")
-            p['pamrp_exit_long']  = st.slider("Exit Long (overbought)", 50, 100, p['pamrp_exit_long'],  key="pxl_exit")
-            p['pamrp_exit_short'] = st.slider("Exit Short (oversold)",  0,   50,  p['pamrp_exit_short'], key="pxs_exit")
-
-    with st.expander("📈 Stoch RSI Exit", expanded=False):
-        p['stoch_rsi_exit_enabled'] = st.toggle("Enable", p['stoch_rsi_exit_enabled'], key="sre")
-        if p['stoch_rsi_exit_enabled']:
-            p['stoch_rsi_length'] = st.slider("Length", 7, 21, p['stoch_rsi_length'], key="srl")
-            p['stoch_rsi_k'] = st.slider("K", 2, 5, p['stoch_rsi_k'], key="srk")
-            p['stoch_rsi_d'] = st.slider("D", 2, 5, p['stoch_rsi_d'], key="srd")
-            p['stoch_rsi_overbought'] = st.slider("OB", 60, 90, p['stoch_rsi_overbought'], key="srob")
-            p['stoch_rsi_oversold'] = st.slider("OS", 10, 40, p['stoch_rsi_oversold'], key="sros")
-
-    with st.expander("⏱️ Time Exit", expanded=False):
-        p['time_exit_enabled'] = st.toggle("Enable", p['time_exit_enabled'], key="txe")
-        if p['time_exit_enabled']:
-            p['time_exit_bars'] = st.slider("Max Bars", 5, 100, p['time_exit_bars'], key="txb")
-
-    with st.expander("📈 MA Exit", expanded=False):
-        p['ma_exit_enabled'] = st.toggle("Enable", p['ma_exit_enabled'], key="mxe")
-        if p['ma_exit_enabled']:
-            p['ma_exit_fast'] = st.slider("Fast", 3, 20, p['ma_exit_fast'], key="mxf")
-            p['ma_exit_slow'] = st.slider("Slow", 10, 40, p['ma_exit_slow'], key="mxs")
-
-    with st.expander("📊 BBWP Exit", expanded=False):
-        p['bbwp_exit_enabled'] = st.toggle("Enable", p['bbwp_exit_enabled'], key="bxe")
-        if p['bbwp_exit_enabled']:
-            p['bbwp_exit_threshold'] = st.slider("Threshold", 60, 95, p['bbwp_exit_threshold'], key="bxt")
+    render_indicator_section("exit", p)
+    render_indicator_section("risk", p)

--- a/ui/sidebar_renderer.py
+++ b/ui/sidebar_renderer.py
@@ -1,0 +1,86 @@
+"""
+ui/sidebar_renderer.py
+======================
+Registry-driven sidebar widget rendering.
+
+render_indicator_section() iterates IndicatorSpecs for a given group,
+renders one expander per spec, and returns nothing — it mutates `p` in place.
+
+Widget keys use the canonical pattern `widget_{param.name}`.
+This is stable across reruns and unique by registry validation guarantee.
+"""
+from typing import Any, Dict
+
+import streamlit as st
+
+from src.indicators.registry import INDICATOR_REGISTRY, ParamSpec
+
+
+def render_param_widget(param: ParamSpec, current_value: Any) -> Any:
+    """Render a single Streamlit widget for a ParamSpec. Returns the new value."""
+    key   = f"widget_{param.name}"
+    label = param.label or param.name
+
+    if param.type == "bool":
+        return st.toggle(label, value=bool(current_value), key=key)
+
+    if param.type == "int":
+        step = int(param.step) if param.step is not None else 1
+        return st.slider(
+            label,
+            min_value=int(param.min),
+            max_value=int(param.max),
+            value=int(current_value),
+            step=step,
+            key=key,
+        )
+
+    if param.type == "float":
+        step = float(param.step) if param.step is not None else 0.5
+        return st.slider(
+            label,
+            min_value=float(param.min),
+            max_value=float(param.max),
+            value=float(current_value),
+            step=step,
+            key=key,
+        )
+
+    if param.type == "categorical":
+        choices = list(param.choices)
+        try:
+            idx = choices.index(current_value)
+        except (ValueError, TypeError):
+            idx = 0
+        return st.selectbox(label, choices, index=idx, key=key)
+
+    return current_value
+
+
+def render_indicator_section(group: str, p: Dict[str, Any]) -> None:
+    """
+    Render all indicator expanders for a given group ("entry", "exit", "risk").
+    Mutates `p` in place with updated param values.
+    """
+    specs = sorted(
+        (s for s in INDICATOR_REGISTRY if s.group == group),
+        key=lambda s: s.order,
+    )
+
+    for spec in specs:
+        # Non-optimizable enable params (type=bool, optimize=False) double as the
+        # expander toggle — render them first so the expander header is descriptive.
+        with st.expander(spec.name, expanded=False):
+            # Enable toggle (always the enable_param)
+            enable_ps = next(ps for ps in spec.params if ps.name == spec.enable_param)
+            p[spec.enable_param] = render_param_widget(
+                enable_ps, p.get(spec.enable_param, enable_ps.default)
+            )
+
+            if p[spec.enable_param]:
+                for param in sorted(spec.params, key=lambda ps: ps.order):
+                    if param.name == spec.enable_param:
+                        continue
+                    p[param.name] = render_param_widget(
+                        param, p.get(param.name, param.default)
+                    )

--- a/ui/tabs/optimize.py
+++ b/ui/tabs/optimize.py
@@ -9,6 +9,7 @@ import streamlit as st
 
 from src.optimize import optimize_strategy
 from src.strategy import TradeDirection
+from src.indicators.registry import INDICATOR_REGISTRY
 from ui.helpers import get_active_filters_display, apply_best_params_callback
 from ui.state_migration import migrate_legacy_pamrp_pins
 from ui.charts import (
@@ -16,43 +17,6 @@ from ui.charts import (
     create_stitched_equity_chart,
     create_optimization_chart,PLOTLY_CONFIG
 )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Pinnable parameter registry
-# ─────────────────────────────────────────────────────────────────────────────
-
-_PINNABLE = {
-    'pamrp_enabled': [('pamrp_entry_ma_length', 'MA Length'), ('pamrp_entry_lookback', 'Lookback'),
-        ('pamrp_entry_ma_type', 'MA Type'), ('pamrp_entry_long', 'Entry Long'), ('pamrp_entry_short', 'Entry Short')],
-    'pamrp_exit_enabled': [('pamrp_exit_ma_length', 'MA Length'), ('pamrp_exit_lookback', 'Lookback'),
-        ('pamrp_exit_ma_type', 'MA Type'), ('pamrp_exit_long', 'Exit Long'), ('pamrp_exit_short', 'Exit Short')],
-    'bbwp_enabled': [('bbwp_length', 'Length'), ('bbwp_lookback', 'Lookback'), ('bbwp_sma_length', 'SMA Length'),
-        ('bbwp_ma_filter', 'MA Filter'), ('bbwp_threshold_long', 'Thresh Long'), ('bbwp_threshold_short', 'Thresh Short')],
-    'adx_enabled': [('adx_length', 'Length'), ('adx_smoothing', 'Smoothing'), ('adx_threshold', 'Threshold')],
-    'ma_trend_enabled': [('ma_type', 'Type'), ('ma_fast_length', 'Fast'), ('ma_slow_length', 'Slow')],
-    'rsi_enabled': [('rsi_length', 'Length'), ('rsi_oversold', 'Oversold'), ('rsi_overbought', 'Overbought')],
-    'volume_enabled': [('volume_ma_length', 'MA Length'), ('volume_multiplier', 'Multiplier')],
-    'supertrend_enabled': [('supertrend_period', 'Period'), ('supertrend_multiplier', 'Multiplier')],
-    'macd_enabled': [('macd_fast', 'Fast'), ('macd_slow', 'Slow'), ('macd_signal', 'Signal')],
-    'stop_loss_enabled': [('stop_loss_pct_long', '% Long'), ('stop_loss_pct_short', '% Short')],
-    'take_profit_enabled': [('take_profit_pct_long', '% Long'), ('take_profit_pct_short', '% Short')],
-    'trailing_stop_enabled': [('trailing_stop_pct', 'Trail %')],
-    'atr_trailing_enabled': [('atr_length', 'Length'), ('atr_multiplier', 'Multiplier')],
-    'time_exit_enabled': [('time_exit_bars', 'Max Bars')],
-    'ma_exit_enabled': [('ma_exit_fast', 'Fast'), ('ma_exit_slow', 'Slow')],
-    'bbwp_exit_enabled': [('bbwp_exit_threshold', 'Threshold')],
-}
-
-_INDICATOR_LABELS = {
-    'pamrp_enabled': 'PAMRP', 'pamrp_exit_enabled': 'PAMRP Exit',
-    'bbwp_enabled': 'BBWP', 'adx_enabled': 'ADX',
-    'ma_trend_enabled': 'MA Trend', 'rsi_enabled': 'RSI', 'volume_enabled': 'Volume',
-    'supertrend_enabled': 'Supertrend', 'macd_enabled': 'MACD',
-    'stop_loss_enabled': 'Stop Loss', 'take_profit_enabled': 'Take Profit',
-    'trailing_stop_enabled': 'Trailing Stop', 'atr_trailing_enabled': 'ATR Trail',
-    'time_exit_enabled': 'Time Exit', 'ma_exit_enabled': 'MA Exit', 'bbwp_exit_enabled': 'BBWP Exit',
-}
 
 _SIDEBAR_TO_OPT_DIRECTION = {
     'Long Only': 'long_only',
@@ -149,10 +113,16 @@ def render_optimize_tab() -> None:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _render_pin_expander() -> None:
+    # Derive pinnable specs from the registry: enabled specs with ≥1 optimizable non-enable param
     enabled_pinnable = [
-        (ind_key, _INDICATOR_LABELS.get(ind_key, ind_key), params_list)
-        for ind_key, params_list in _PINNABLE.items()
-        if st.session_state.params.get(ind_key, False)
+        (
+            spec.enable_param,
+            spec.name,
+            [(p.name, p.label or p.name) for p in spec.params if p.name != spec.enable_param and p.optimize],
+        )
+        for spec in INDICATOR_REGISTRY
+        if st.session_state.params.get(spec.enable_param, False)
+        and any(p.name != spec.enable_param and p.optimize for p in spec.params)
     ]
     pinned_set: set = migrate_legacy_pamrp_pins(st.session_state.pinned_params)
 
@@ -182,7 +152,7 @@ def _render_pin_expander() -> None:
     if pinned_set:
         pinned_names = ', '.join(
             next((pl for pk, pl in p_list if pk == k), k)
-            for ind_key, _, p_list in enabled_pinnable
+            for _, _, p_list in enabled_pinnable
             for k in pinned_set if any(pk == k for pk, _ in p_list)
         )
         st.caption(f"🔒 Pinned: **{pinned_names}**")


### PR DESCRIPTION
<html><head></head><body><h1>Indicator Registry Refactor — Implementation Spec</h1>
<p><strong>Labels:</strong> <code>architecture</code>, <code>refactor</code>, <code>high-impact</code>
<strong>Status:</strong> Ready for Claude Code execution
<strong>Owner:</strong> Kristi
<strong>Regression standard:</strong> bit-identical trade logs across all phases</p>
<hr>
<h2>1. Problem</h2>
<p>Adding a single indicator (e.g. Bollinger %B) requires touching <strong>six locations</strong>:</p>

Location | Coupling
-- | --
src/strategy/__init__.py → StrategyParams dataclass | Per-indicator typed fields (rsi_enabled, rsi_length, rsi_oversold, rsi_overbought, …)
src/strategy/__init__.py → SignalGenerator.calculate_indicators() | Per-indicator if block computing columns
src/strategy/__init__.py → generate_entry_signals() / generate_exit_signals() | Per-indicator mask construction with hardcoded column names
src/optimize/__init__.py → _build_params_from_trial() | Per-indicator suggest_int / suggest_float blocks with hardcoded bounds and direction-aware skip logic
src/optimize/__init__.py → _count_active_params() | Manual dims_per_indicator dict
ui/helpers.py + ui/sidebar.py | PARAM_TO_WIDGET_KEY map, params_to_strategy() field-by-field construction, get_active_filters_display() label dict, sidebar expanders


<hr>
<h2>9. Out-of-scope-but-related</h2>
<ul>
<li>The pending <strong><code>allow_same_bar_exit</code> toggle</strong> issue is not part of this refactor. Land it before or after, not during — it touches <code>StrategyParams</code> and would muddle the regression baseline.</li>
<li>The pending <strong>gap-aware slippage regression test</strong> (<code>GAP_AWARE_EXITS</code> exclusion set) should land in Phase 0 — same harness, different fixture configs that exercise gap-through stops. Do it now while you're building the regression infrastructure.</li>
</ul></body></html>